### PR TITLE
allowing the 'ws-server' to process plain http GET requests

### DIFF
--- a/src/riemann/common.clj
+++ b/src/riemann/common.clj
@@ -117,16 +117,16 @@
         [[:time (unix-time)]
          [:state "expired"]]))
 
-(defn event-with-iso8601-time
+(defn event->structure
   "change the event's time from a unix ts to a iso8601 time"
   [event]
   (assoc event :time (unix-to-iso8601 (:time event))))
 
-(defn event-to-json
+(defn event->json
   "Convert an event to a JSON string."
   [event]
   (json/generate-string
-    (event-with-iso8601-time event)))
+    (event->structure event)))
 
 (defn ensure-event-time
   "Ensures an event has a timestamp."

--- a/src/riemann/common.clj
+++ b/src/riemann/common.clj
@@ -117,11 +117,16 @@
         [[:time (unix-time)]
          [:state "expired"]]))
 
+(defn event-with-iso8601-time
+  "change the event's time from a unix ts to a iso8601 time"
+  [event]
+  (assoc event :time (unix-to-iso8601 (:time event))))
+
 (defn event-to-json
   "Convert an event to a JSON string."
   [event]
   (json/generate-string
-    (assoc event :time (unix-to-iso8601 (:time event)))))
+    (event-with-iso8601-time event)))
 
 (defn ensure-event-time
   "Ensures an event has a timestamp."

--- a/src/riemann/logstash.clj
+++ b/src/riemann/logstash.clj
@@ -108,5 +108,5 @@
     (fn [event]
       (when (:metric event)
         (with-pool [client pool (:claim-timeout opts)]
-                   (let [string (event-to-json (merge event {:source (:host event)}))]
+                   (let [string (event->json (merge event {:source (:host event)}))]
                      (send-line client (str string "\n"))))))))

--- a/src/riemann/transport/sse.clj
+++ b/src/riemann/transport/sse.clj
@@ -16,7 +16,7 @@
 (def event-to-server-sent-event
   "Prepare an event for sending out on the wire."
   (comp (partial format "data: %s\n\n")
-        common/event-to-json))
+        common/event->json))
 
 (defn http-query-map
   "Converts a URL query string into a map."

--- a/src/riemann/transport/websockets.clj
+++ b/src/riemann/transport/websockets.clj
@@ -7,7 +7,7 @@
             [cheshire.core         :as json]
             [interval-metrics.core :as metrics]
             [org.httpkit.server    :as http])
-  (:use [riemann.common        :only [event-to-json ensure-event-time]]
+  (:use [riemann.common        :only [event-to-json ensure-event-time event-with-iso8601-time]]
         [riemann.core          :only [stream!]]
         [riemann.instrumentation :only [Instrumented]]
         [riemann.service       :only [Service ServiceEquiv]]
@@ -16,7 +16,8 @@
         [clojure.java.io       :only [reader]]
         [clojure.tools.logging :only [info warn debug]]
         [clj-http.util         :only [url-decode]]
-        [clojure.string        :only [split]])
+        [clojure.string        :only [split]]
+        [slingshot.slingshot   :only [throw+ try+]])
   (:import (java.io OutputStream
                     BufferedWriter
                     OutputStreamWriter
@@ -27,10 +28,86 @@
 (defn http-query-map
   "Converts a URL query string into a map."
   [string]
-  (apply hash-map
-         (map url-decode
-              (mapcat (fn [kv] (split kv #"=" 2))
-                      (split string #"&")))))
+  (if-not (nil? string)
+    (apply hash-map
+           (map url-decode
+                (mapcat (fn [kv] (split kv #"=" 2))
+                        (split string #"&"))))
+    {})) ; empty map if no query string
+
+(defn json-response [status body]
+  "generate a ring http response with a json body"
+  {
+    :status status
+    :headers {"Content-Type" "application/json"}
+    :body (json/encode body)
+    })
+
+(defn apply-paging [s offset limit]
+  (take limit (drop offset s)))
+
+(defn integer-param
+  "grab and prase a value from a map, with optional predicate"
+  ([params key default] (let [key-name (name key)]
+                          (if (contains? params key-name)
+                            (try
+                              (Integer/parseInt (params key-name))
+                              (catch NumberFormatException e
+                                (throw (IllegalArgumentException. (str "parameter " key-name " is not an integer")))))
+                            default)))
+
+  ([params key default pred] (let [result (integer-param params key default)]
+                               (if (pred result)
+                                 result
+                                 (throw (IllegalArgumentException. (str "parameter " (name key) " is not valid")))
+                                 ))))
+
+(defn paged-items
+  [items offset limit]
+  {:items (map event-with-iso8601-time (apply-paging items offset limit))})
+
+(defn uri-parts [uri]
+  "returns a sequence of decoded uri parts.
+
+  (uri-parts \"/thing/that/foo\")
+  > (\"thing\" \"that\" \"foo\"
+
+   is limited to first, second, third and the rest (ie max 4)
+  "
+  (drop 1 ; first element will be "" matching the chars 'before' '/'
+        (map url-decode (split uri #"/" 5)))) ; note 5 limits it to /first/second/third/rest
+
+(defn http-get-events [core req]
+  (try+
+    (let [params (http-query-map (:query-string req))
+          offset (integer-param params :offset 0 #(>= % 0))
+          limit  (integer-param params :limit 250 pos?)
+          query  (get params "query")
+          index  (:index core)
+          items  (if (nil? query)
+                   index
+                   (index/search index (query/ast query)))]
+      (json-response 200 (paged-items items offset limit)))
+    (catch [:type :riemann.query/parse-error] {:keys [message]}
+      (json-response 400 {:message (str "'query' parameter is not a valid query detail:" message)}))
+    (catch IllegalArgumentException e
+      (json-response 400 {:message (.getMessage e)}))))
+
+(defn http-get-events-by-host [core req host]
+  (try
+    (let [params (http-query-map (:query-string req))
+          offset (integer-param params :offset 0)
+          limit  (integer-param params :limit 250)
+          items  (filter #(= (:host %) host) (:index core))]
+      (json-response 200 (paged-items items offset limit)))
+    (catch IllegalArgumentException e
+      (json-response 400 {:message (.getMessage e)}))))
+
+(defn http-get-events-by-host-service [core req host service]
+  (let [event (index/lookup (:index core) host service)]
+    (if-not (nil? event)
+      (json-response 200 (event-with-iso8601-time event))
+      (json-response 404 {:message "no such event"}))))
 
 (defn ws-pubsub-handler
   "Subscribes to a pubsub channel and streams events back over the WS conn."
@@ -76,6 +153,26 @@
       (if (= (params "subscribe") "true")
         (ws-pubsub-handler core stats ch (assoc hs :uri "/pubsub/index") actions)
         (http/close ch)))))
+
+
+(defn http-index-handler
+  [core stats ch req]
+  (let [parts (drop 1 (uri-parts (:uri req)))] ; drop the 'index' bit
+    (http/send! ch
+                (condp re-matches (:uri req)
+                  #"/index/?"            (http-get-events core req)
+                  #"/index/[^/]+"        (http-get-events-by-host core req (first parts))
+                  #"/index/[^/]+/[^/]+"  (http-get-events-by-host-service core req (first parts) (second parts))
+                  {:status 404 :body "unknown uri"})
+                true ; send close .. this is http not sockets
+                )))
+
+(defn index-handler
+  "Handles queries to the internal index"
+  [core stats ch req actions]
+  (if (http/websocket? ch)
+    (ws-index-handler core stats ch req actions)
+    (http-index-handler core stats ch req)))
 
 (defn input-event!
   [core stats event]
@@ -152,11 +249,12 @@
           ;; Route request
           (condp re-matches (:uri req)
             #"/events/?"       (put-events-handler @core stats ch req)
-            #"/index/?"        (ws-index-handler @core stats ch req actions)
+            #"/index.*"        (index-handler @core stats ch req actions)
             #"/pubsub/[^/]+/?" (ws-pubsub-handler @core stats ch req actions)
+
             (do
               (info "Unknown URI " (:uri req) ", closing")
-              (http/close ch))))
+              (http/send! ch (json-response 404 (str "no such uri")) true))))
 
         (catch Throwable t
           (do
@@ -224,14 +322,73 @@
              ))))
 
 (defn ws-server
-  "Starts a new websocket server for a core. Starts immediately.
+  "Starts a new http/websocket server for a core. Starts immediately.
 
   Options:
   :host   The address to listen on (default 127.0.0.1)
-          Currently does nothing; this option depends on an incomplete
-          feature in Aleph, the underlying networking library. Aleph will
-          currently bind to all interfaces, regardless of this value.
-  :port   The port to listen on (default 5556)"
+  :post   The port to listen on (default 5556)
+
+  This provides two styles of accessing riemann, websockets and plain
+  http. Both methods encode events in the same way.
+
+  Example json encoded event:
+
+  {
+     \"host\":\"host1.example.com\",
+     \"service\":\"load\",
+     \"state\":\"ok\",
+     \"description\":\"1-minute load average per core is 0.0\",
+     \"metric\":0.0,
+     \"tags\":null,
+     \"time\":\"2014-07-28T07:40:40.000Z\",
+     \"ttl\":10.0
+  }
+
+  Note that the 'time' field is a ISO8601 (yyyy-MM-dd'T'HH:mm:ss.SSSZZ)
+
+  websockets:
+
+  All websocket requests accept or return events encoded as json
+  seperated by a single '\n' char.
+
+  /events inbound connection to publish events
+  /index  query the index
+          query parameters:
+          'query' - riemann query to select events
+          'subscribe' - if 'true' the connection will remain open
+                        and will stream all matching new events
+  /pubsub/{topic}
+          'query' - riemann query to select events from the topic
+
+
+  Plain HTTP:
+
+  output is in json, and lists are structured as
+
+  {
+     \"items\":[
+        {\"host\":\"host\", \"service\":\"load\"},
+        {\"host\":\"host\", \"service\":\"cpu\"},
+     ]
+  }
+
+  lists can be paged using query parameters 'offset' and 'limit'
+  but it should be noted that because of the nature of the internal
+  index of riemann no guarantees on ordering. It is expected that
+  the http style interface is used more for debugging and manual
+  introspection than for system integration.
+
+  GET /index - list of all events in the index
+                query parameters:
+                'offset' - offset of first item to return
+                'limit'  - max number to return (defualt is 250)
+                'query'  - riemann query to match events against
+  GET /index/{hostname} - list of all events for a single host
+                query parameters:
+                'offset' - offset of first item to return
+                'limit'  - max number to return (defualt is 250)
+
+  GET /index/{hostname}/{service} - a single event"
   ([] (ws-server {}))
   ([opts]
    (WebsocketServer.

--- a/test/riemann/common_test.clj
+++ b/test/riemann/common_test.clj
@@ -119,7 +119,7 @@
   (is (= (truncate-bytes "あいう" 10) "あいう")))
 
 (deftest event-with-iso8601-time-test
-  (let [events (map #(event-with-iso8601-time {:time %})
+  (let [events (map #(event->structure {:time %})
                     [1366074418
                      1366009618
                      1366049218

--- a/test/riemann/common_test.clj
+++ b/test/riemann/common_test.clj
@@ -117,3 +117,17 @@
   (is (= (truncate-bytes "あいう" 4) "あ"))
   (is (= (truncate-bytes "あいう" 9) "あいう"))
   (is (= (truncate-bytes "あいう" 10) "あいう")))
+
+(deftest event-with-iso8601-time-test
+  (let [events (map #(event-with-iso8601-time {:time %})
+                    [1366074418
+                     1366009618
+                     1366049218
+                     1365984000])]
+    (is (= events [
+                    {:time "2013-04-16T01:06:58.000Z"}
+                    {:time "2013-04-15T07:06:58.000Z"}
+                    {:time "2013-04-15T18:06:58.000Z"}
+                    {:time "2013-04-15T00:00:00.000Z"}
+                    ]))
+    ))

--- a/test/riemann/transport/websockets_test.clj
+++ b/test/riemann/transport/websockets_test.clj
@@ -1,0 +1,95 @@
+(ns riemann.transport.websockets-test
+  (:require [riemann.transport.websockets :as ws]
+            [cheshire.core                :as json])
+  (:use riemann.common
+        [riemann.index :only [index,update]]
+        [riemann.logging :only [suppress]]
+        [riemann.time :only [unix-time]]
+        [clj-http.util         :only [url-encode]]
+        clojure.test))
+
+(def empty-core {:index (index)})
+(def empty-request  {:query-string nil})
+
+(defn request-with [key value]
+  (let [query-string (str (name key) "=" (url-encode (str value)))]
+    (assoc empty-request
+      :query-string query-string)))
+
+(deftest get-events-test
+  (let
+      [result (ws/http-get-events empty-core empty-request)]
+    (is (= (result :status) 200))
+    (is (= ((result :headers) "Content-Type") "application/json"))
+    ))
+
+(deftest get-events-with-query-test
+  (let [idx  (index)
+        core {:index idx}]
+    (doall
+      (map #(update idx {:host (str "host" % ".example.com") :service "thing" :time (unix-time)})
+           (range 1 100)))
+    (let [result (ws/http-get-events core (request-with :query "host = \"host3.example.com\""))
+          body (result :body)
+          items ((json/decode body) "items")]
+      (is (= (result :status) 200))
+      (is (= (count items) 1))
+      )))
+
+(deftest get-events-paging-test
+  (let [idx  (index)
+        core {:index idx}]
+    (doall
+      (map #(update idx {:host (str "host" % ".example.com") :service "thing" :time (unix-time)})
+           (range 1 1000)))
+    (let [result (ws/http-get-events core (request-with :limit 200))
+          body (result :body)
+          items ((json/decode body) "items")]
+      (is (= (count items) 200)))
+    (let [result (ws/http-get-events core (request-with :offset 989))
+          body (result :body)
+          items ((json/decode body) "items")]
+      ; should be the last ten elements
+      (is (= (count items) 10)))
+
+    ))
+
+(deftest get-events-host
+  (let [idx  (index)
+        core {:index idx}]
+    (doall
+      (map #(update idx {:host (str "host" % ".example.com") :service "thing" :time (unix-time)})
+           (range 1 10)))
+    (let [result (ws/http-get-events-by-host core empty-request "host2.example.com")
+          body (result :body)
+          items ((json/decode body) "items")]
+      (is (= (count items) 1))
+      (is (= (result :status) 200)))
+    ))
+
+(deftest get-events-host-service
+  (let [idx  (index)
+        core {:index idx}]
+    (update idx {:host "host1.example.com" :service "wibble" :time (unix-time)})
+    (let [result (ws/http-get-events-by-host-service core empty-request "host1.example.com" "wibble")
+          body (result :body)
+          event (json/decode body)]
+      (is (= (event "host") "host1.example.com"))
+      (is (= (event "service") "wibble"))
+      (is (= (result :status) 200)))
+    (let [result (ws/http-get-events-by-host-service core empty-request "doesnotexist.example.com" "wibble")]
+      (is (= (result :status) 404)))
+    ))
+
+(deftest get-events-returns-400
+  (is (= ((ws/http-get-events empty-core (request-with :limit "not value")) :status) 400))
+  (is (= ((ws/http-get-events empty-core (request-with :offset "-1")) :status) 400))
+  (is (= ((ws/http-get-events empty-core (request-with :query "not a query")) :status) 400))
+  )
+
+(deftest integer-param-test
+  (is (= (ws/integer-param {"p" "123"} :p 321) 123))
+  (is (= (ws/integer-param {"missing" "123"} :p 321) 321))
+  (is (thrown? IllegalArgumentException (ws/integer-param {"p" "banana"} :p 1)))
+  (is (thrown? IllegalArgumentException (ws/integer-param {"p" "-1"} :p 1 pos?)))
+  )

--- a/test/riemann/transport/websockets_test.clj
+++ b/test/riemann/transport/websockets_test.clj
@@ -9,7 +9,7 @@
         clojure.test))
 
 (def empty-core {:index (index)})
-(def empty-request  {:query-string nil})
+(def empty-request  {:query-string nil :request-method :get})
 
 (defn request-with [key value]
   (let [query-string (str (name key) "=" (url-encode (str value)))]

--- a/test/riemann/transport/websockets_test.clj
+++ b/test/riemann/transport/websockets_test.clj
@@ -54,33 +54,6 @@
 
     ))
 
-(deftest get-events-host
-  (let [idx  (index)
-        core {:index idx}]
-    (doall
-      (map #(update idx {:host (str "host" % ".example.com") :service "thing" :time (unix-time)})
-           (range 1 10)))
-    (let [result (ws/http-get-events-by-host core empty-request "host2.example.com")
-          body (result :body)
-          items ((json/decode body) "items")]
-      (is (= (count items) 1))
-      (is (= (result :status) 200)))
-    ))
-
-(deftest get-events-host-service
-  (let [idx  (index)
-        core {:index idx}]
-    (update idx {:host "host1.example.com" :service "wibble" :time (unix-time)})
-    (let [result (ws/http-get-events-by-host-service core empty-request "host1.example.com" "wibble")
-          body (result :body)
-          event (json/decode body)]
-      (is (= (event "host") "host1.example.com"))
-      (is (= (event "service") "wibble"))
-      (is (= (result :status) 200)))
-    (let [result (ws/http-get-events-by-host-service core empty-request "doesnotexist.example.com" "wibble")]
-      (is (= (result :status) 404)))
-    ))
-
 (deftest get-events-returns-400
   (is (= ((ws/http-get-events empty-core (request-with :limit "not value")) :status) 400))
   (is (= ((ws/http-get-events empty-core (request-with :offset "-1")) :status) 400))


### PR DESCRIPTION
This is a port of the changes proposed in https://github.com/aphyr/riemann/pull/422

I've switched the uri's to /index and the 'q' parameter is now 'query' to be consistent with the existing websockets uris.

provides:
    GET /index list of all events in the index
                query parameters:
                'offset' - offset of first item to return
                'limit'  - max number to return (defualt is 250)
                'query'  - riemann query to match events against