### PR TITLE
Add plugin for output to Keen IO

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -29,6 +29,7 @@
         [riemann.plugin  :only [load-plugin load-plugins]]
         [riemann.time :only [unix-time linear-time once! every!]]
         [riemann.pagerduty :only [pagerduty]]
+        [riemann.keenio :only [keenio]]
         [riemann.campfire :only [campfire]]
         [riemann.kairosdb :only [kairosdb]]
         [riemann.librato :only [librato-metrics]]

--- a/src/riemann/keenio.clj
+++ b/src/riemann/keenio.clj
@@ -10,8 +10,8 @@
   "POST to Keen IO."
   [collection project-id write-key request]
 
-  (def final-event-url
-    (str event-url project-id "/events/" collection))
+  (let [final-event-url
+    (str event-url project-id "/events/" collection)]
 
   (client/post final-event-url
                {:body (json/generate-string request)
@@ -20,7 +20,7 @@
                 :conn-timeout 5000
                 :content-type :json
                 :accept :json
-                :throw-entire-message? true}))
+                :throw-entire-message? true})))
 
 (defn keenio
   "Creates a keen adapter. Takes your Keen project id and write key, and
@@ -28,7 +28,7 @@
   event will be sent.
 
 (streams
-  (let [kio (keenio \"COLLECTION_NAME\", \"PROJECT_ID\" \"WRITE_KEY\")]
+  (let [kio (keenio \"COLLECTION_NAME\" \"PROJECT_ID\" \"WRITE_KEY\")]
     (where (state \"error\") kio)))"
 
   [collection project-id, write-key]

--- a/src/riemann/keenio.clj
+++ b/src/riemann/keenio.clj
@@ -6,12 +6,12 @@
 (def ^:private event-url
   "https://api.keen.io/3.0/projects/")
 
-(defn- post
+(defn post
   "POST to Keen IO."
   [collection project-id write-key request]
 
   (let [final-event-url
-    (str event-url project-id "/events/" collection)]
+       (str event-url project-id "/events/" collection)]
 
   (client/post final-event-url
                {:body (json/generate-string request)
@@ -27,10 +27,10 @@
   returns a function that accepts an event and sends it to Keen IO. The full
   event will be sent.
 
-(streams
-  (let [kio (keenio \"COLLECTION_NAME\" \"PROJECT_ID\" \"WRITE_KEY\")]
-    (where (state \"error\") kio)))"
+  (streams
+    (let [kio (keenio \"COLLECTION_NAME\" \"PROJECT_ID\" \"WRITE_KEY\")]
+      (where (state \"error\") kio)))"
 
-  [collection project-id, write-key]
+  [collection project-id write-key]
   (fn [event]
     (post collection project-id write-key event)))

--- a/src/riemann/keenio.clj
+++ b/src/riemann/keenio.clj
@@ -25,7 +25,7 @@
 (defn keenio
   "Creates a keen adapter. Takes your Keen project id and write key, and
   returns a function that accepts an event and sends it to Keen IO. The full
-  event will sent.
+  event will be sent.
 
 (streams
   (let [kio (keenio \"COLLECTION_NAME\", \"PROJECT_ID\" \"WRITE_KEY\")]

--- a/src/riemann/keenio.clj
+++ b/src/riemann/keenio.clj
@@ -1,0 +1,36 @@
+(ns riemann.keenio
+  "Forwards events to Keen IO"
+  (:require [clj-http.client :as client])
+  (:require [cheshire.core :as json]))
+
+(def ^:private event-url
+  "https://api.keen.io/3.0/projects/")
+
+(defn- post
+  "POST to Keen IO."
+  [collection project-id write-key request]
+
+  (def final-event-url
+    (str event-url project-id "/events/" collection))
+
+  (client/post final-event-url
+               {:body (json/generate-string request)
+                :query-params { "api_key" write-key }
+                :socket-timeout 5000
+                :conn-timeout 5000
+                :content-type :json
+                :accept :json
+                :throw-entire-message? true}))
+
+(defn keenio
+  "Creates a keen adapter. Takes your Keen project id and write key, and
+  returns a function that accepts an event and sends it to Keen IO. The full
+  event will sent.
+
+(streams
+  (let [kio (keenio \"COLLECTION_NAME\", \"PROJECT_ID\" \"WRITE_KEY\")]
+    (where (state \"error\") kio)))"
+
+  [collection project-id, write-key]
+  (fn [event]
+    (post collection project-id write-key event)))


### PR DESCRIPTION
Like it says on the tin! :smile: 

We're clojure noobs and this was largely snagged from the Pagerduty and OpenTSDB plugins.

We like to batch events for performance reasons but I didn't see any examples of outputs that batch things up. I know this can be accomplished inside riemann but it will still cause us to send multiple POSTs instead of one big one periodically. Thoughts?

Thanks for any tips, improvements or suggestions.