### PR TITLE
Remove extra travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,3 @@ jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
-branches:
-  except:
-    - gh-pages


### PR DESCRIPTION
I found that travis build fails:
https://travis-ci.org/aphyr/riemann/jobs/45572720
I'm not sure that proposed change going to fix that but It's definitely [not required](http://docs.travis-ci.com/user/build-configuration/#White--or-blacklisting-branches) as travis states:
```
Note that the gh-pages branch will not be built unless you add it to the whitelist
```