### PR TITLE
Include original event when capturing call rescue exception

### DIFF
--- a/src/riemann/common.clj
+++ b/src/riemann/common.clj
@@ -145,7 +145,7 @@
                 :service "riemann exception"
                 :state "error"
                 :tags ["exception" (.getName (class e))]
-                :original-event original
+                :event original
                 :description (str e "\n\n"
                                   (join "\n" (.getStackTrace e)))})))
 

--- a/src/riemann/common.clj
+++ b/src/riemann/common.clj
@@ -139,13 +139,15 @@
 
 (defn exception->event
   "Creates an event from an Exception."
-  [^Throwable e]
-  (map->Event {:time (unix-time)
-               :service "riemann exception"
-               :state "error"
-               :tags ["exception" (.getName (class e))]
-               :description (str e "\n\n"
-                                 (join "\n" (.getStackTrace e)))}))
+  ([exception] (exception->event exception nil))
+  ([^Throwable e original]
+   (map->Event {:time (unix-time)
+                :service "riemann exception"
+                :state "error"
+                :tags ["exception" (.getName (class e))]
+                :original-event original
+                :description (str e "\n\n"
+                                  (join "\n" (.getStackTrace e)))})))
 
 (defn approx-equal
   "Returns true if x and y are roughly equal, such that x/y is within tol of

--- a/src/riemann/common.clj
+++ b/src/riemann/common.clj
@@ -146,6 +146,7 @@
                 :state "error"
                 :tags ["exception" (.getName (class e))]
                 :event original
+                :exception e
                 :description (str e "\n\n"
                                   (join "\n" (.getStackTrace e)))})))
 

--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -70,7 +70,7 @@
          (catch Throwable e#
            (warn e# (str child# " threw"))
            (if-let [ex-stream# *exception-stream*]
-             (ex-stream# (exception->event e#))))))
+             (ex-stream# (exception->event e# ~event))))))
      ; TODO: Why return true?
      true))
 

--- a/test/riemann/common_test.clj
+++ b/test/riemann/common_test.clj
@@ -117,3 +117,10 @@
   (is (= (truncate-bytes "あいう" 4) "あ"))
   (is (= (truncate-bytes "あいう" 9) "あいう"))
   (is (= (truncate-bytes "あいう" 10) "あいう")))
+
+(deftest exception->event-test
+  (is (= ["exception" "clojure.lang.ExceptionInfo"]
+         (:tags (exception->event (ex-info "fake test error" {})))))
+
+  (is (= "original-event"
+         (:service (:original-event (exception->event (ex-info "fake test error" {}) {:service "original-event"}))))))

--- a/test/riemann/common_test.clj
+++ b/test/riemann/common_test.clj
@@ -123,4 +123,4 @@
          (:tags (exception->event (ex-info "fake test error" {})))))
 
   (is (= "original-event"
-         (:service (:original-event (exception->event (ex-info "fake test error" {}) {:service "original-event"}))))))
+         (:service (:event (exception->event (ex-info "fake test error" {}) {:service "original-event"}))))))

--- a/test/riemann/common_test.clj
+++ b/test/riemann/common_test.clj
@@ -122,5 +122,9 @@
   (is (= ["exception" "clojure.lang.ExceptionInfo"]
          (:tags (exception->event (ex-info "fake test error" {})))))
 
+  (let [e (ex-info "fake test error" {})]
+    (is (= e
+         (:exception (exception->event e)))))
+
   (is (= "original-event"
          (:service (:event (exception->event (ex-info "fake test error" {}) {:service "original-event"}))))))


### PR DESCRIPTION
adds the original event to the event passed to `call-rescue` as a custom attribute, so there's more debugging context