### PR TITLE
Fix Netty native transport issue

### DIFF
--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -72,7 +72,7 @@
 
     (isSharable [] true)))
 
-(def transport
+(def netty-implementation
   (if (.contains (. System getProperty "os.name") "Linux")
     {:event-loop-group-fn #(EpollEventLoopGroup.)
      :channel EpollServerSocketChannel}
@@ -125,7 +125,7 @@
   (start! [this]
           (locking this
             (when-not @killer
-              (let [event-loop-group-fn (:event-loop-group-fn transport)
+              (let [event-loop-group-fn (:event-loop-group-fn netty-implementation)
                     boss-group (event-loop-group-fn)
                     worker-group (event-loop-group-fn)
                     bootstrap (ServerBootstrap.)]
@@ -133,7 +133,7 @@
                 ; Configure bootstrap
                 (doto bootstrap
                   (.group boss-group worker-group)
-                  (.channel (:channel transport))
+                  (.channel (:channel netty-implementation))
                   (.option ChannelOption/SO_REUSEADDR true)
                   (.option ChannelOption/TCP_NODELAY true)
                   (.childOption ChannelOption/SO_REUSEADDR true)

--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -73,6 +73,9 @@
     (isSharable [] true)))
 
 (def netty-implementation
+  "Provide native implementation of Netty for improved performance on
+  Linux only. Provide pure-Java implementation of Netty on all other
+  platforms. See http://netty.io/wiki/native-transports.html"
   (if (.contains (. System getProperty "os.name") "Linux")
     {:event-loop-group-fn #(EpollEventLoopGroup.)
      :channel EpollServerSocketChannel}

--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -18,7 +18,7 @@
            [io.netty.handler.codec LengthFieldBasedFrameDecoder
                                    LengthFieldPrepender]
            [io.netty.handler.ssl SslHandler]
-           [io.netty.channel.epoll EpollEventLoopGroup EpollServerSocketChannel]
+           [io.netty.channel.socket.nio NioServerSocketChannel]
            [io.netty.channel.nio NioEventLoopGroup])
   (:require [less.awful.ssl :as ssl]
             [interval-metrics.core :as metrics])
@@ -117,14 +117,14 @@
   (start! [this]
           (locking this
             (when-not @killer
-              (let [boss-group (EpollEventLoopGroup.)
-                    worker-group (EpollEventLoopGroup.)
+              (let [boss-group (NioEventLoopGroup.)
+                    worker-group (NioEventLoopGroup.)
                     bootstrap (ServerBootstrap.)]
 
                 ; Configure bootstrap
                 (doto bootstrap
                   (.group boss-group worker-group)
-                  (.channel EpollServerSocketChannel)
+                  (.channel NioServerSocketChannel)
                   (.option ChannelOption/SO_REUSEADDR true)
                   (.option ChannelOption/TCP_NODELAY true)
                   (.childOption ChannelOption/SO_REUSEADDR true)

--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -72,8 +72,12 @@
 
     (isSharable [] true)))
 
-(def transport {:event-loop-group-fn #(NioEventLoopGroup.)
-                :channel NioServerSocketChannel})
+(def transport
+  (if (.contains (. System getProperty "os.name") "Linux")
+    {:event-loop-group-fn #(EpollEventLoopGroup.)
+     :channel EpollServerSocketChannel}
+    {:event-loop-group-fn #(NioEventLoopGroup.)
+     :channel NioServerSocketChannel}))
 
 (defn tcp-handler
   "Given a core, a channel, and a message, applies the message to core and


### PR DESCRIPTION
Use `NioServerSocketChannel` and `NioEventLoopGroup` instead of the corresponding `Epoll` classes, since the latter are Linux-specific.