### PR TITLE
upgrade to high-scale-lib v1.0.6 in Maven Central

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,6 @@
 ;  :warn-on-reflection true
 ;  :jvm-opts ["-server" "-d64" "-Xms1024m" "-Xmx1024m" "-XX:+UseParNewGC" "-XX:+UseConcMarkSweepGC" "-XX:+CMSParallelRemarkEnabled" "-XX:+AggressiveOpts" "-XX:+UseFastAccessorMethods" "-verbose:gc" "-XX:+PrintGCDetails"]
   :jvm-opts ["-server" "-Xms1024m" "-Xmx1024m" "-XX:+UseParNewGC" "-XX:+UseConcMarkSweepGC" "-XX:+CMSParallelRemarkEnabled" "-XX:+AggressiveOpts" "-XX:+UseFastAccessorMethods" "-XX:+CMSClassUnloadingEnabled"]
-  :repositories {
-    "boundary-site" "http://maven.boundary.com/artifactory/repo"
-  }
   :maintainer {:email "aphyr@aphyr.com"}
   :dependencies [
     [org.clojure/algo.generic "0.1.2"]
@@ -29,7 +26,7 @@
     [clj-librato "0.0.5"]
     [clj-time "0.9.0"]
     [clj-wallhack "1.0.1"]
-    [com.boundary/high-scale-lib "1.0.4"]
+    [com.boundary/high-scale-lib "1.0.6"]
     [com.draines/postal "1.11.1"]
     [com.amazonaws/aws-java-sdk "1.7.5"]
     [interval-metrics "1.0.0"]


### PR DESCRIPTION
Eliminates need for Boundary's Maven repo and some related test confusion when the Boundary repo is offline:
* https://github.com/aphyr/riemann/pull/485#issuecomment-69502057
* http://logs.lazybot.org/irc.freenode.net/%23riemann/2014-05-21.txt (at 21:06:16)
  and http://logs.lazybot.org/irc.freenode.net/%23riemann/2014-05-22.txt (at 09:40:26)

`lein test` still passes and `lein run` did not explode, but no further testing done.