### PR TITLE
Fix init script output on RedHat-based distros

### DIFF
--- a/pkg/rpm/init.sh
+++ b/pkg/rpm/init.sh
@@ -35,8 +35,9 @@ start() {
 #    daemon --pidfile $PID_FILE --user $RIEMANN_USER $DAEMON $DAEMON_OPTS
     daemonize -u $RIEMANN_USER -p $PID_FILE -l $LOCK_FILE $DAEMON $DAEMON_OPTS
     RETVAL=$?
-    echo
     [ $RETVAL -eq 0 ] && touch $LOCK_FILE
+    [ $RETVAL -eq 0 ] && success || failure
+    echo
     return $RETVAL
 }
 


### PR DESCRIPTION
Starting Riemann on CentOS/RHEL would output no feedback whether it started successfully or otherwise. I'm assuming the `success` and `failure` functions are defined because the script already assumes `/etc/rc.d/init.d/functions` is available for source'ing.