### PR TITLE
Fix deb and rpm ownerships

### DIFF
--- a/pkg/deb/postinst.sh
+++ b/pkg/deb/postinst.sh
@@ -1,4 +1,10 @@
 #!/bin/sh -e
+# Fakeroot and lein don't get along, so we set ownership after the fact.
+chown -R root:root /usr/share/riemann
+chown root:root /usr/bin/riemann
+chown riemann:riemann /var/log/riemann
+chown -R riemann:riemann /etc/riemann
+chown root:root /etc/init.d/riemann
 
 # Start riemann on boot
 if [ -x "/etc/init.d/riemann" ]; then

--- a/pkg/deb/postinst.sh
+++ b/pkg/deb/postinst.sh
@@ -5,6 +5,7 @@ chown root:root /usr/bin/riemann
 chown riemann:riemann /var/log/riemann
 chown -R riemann:riemann /etc/riemann
 chown root:root /etc/init.d/riemann
+chown root:root /etc/default/riemann
 
 # Start riemann on boot
 if [ -x "/etc/init.d/riemann" ]; then

--- a/tasks/leiningen/fatrpm.clj
+++ b/tasks/leiningen/fatrpm.clj
@@ -99,6 +99,8 @@
        [; Jar
         {:directory "/usr/lib/riemann/"
          :filemode "644"
+         :username "root"
+         :groupname "root"
          :sources [(source (str (file (:root project) 
                                       "target"
                                       (str "riemann-"
@@ -109,6 +111,8 @@
         ; Binary
         {:directory "/usr/bin"
          :filemode "755"
+         :username "root"
+         :groupname "root"
          :sources [(source (file (:root project) "pkg" "rpm" "riemann")
                            "riemann")]}
 
@@ -132,6 +136,8 @@
         ; Default file
         {:directory "/etc/sysconfig"
          :filemode "644"
+         :username "root"
+         :groupname "root"
          :configuration true
          :sources [(source (file (:root project) "pkg" "riemann-default")
                            "riemann")]}


### PR DESCRIPTION
This squashes the ownership discrepencies between deb and rpm packages and fixes an issue reported on the mailing-list.

This would be the resulting ownserships if this patchset is merged:

owned by riemann:
 - `/etc/riemann`
 - `/var/log/riemann`

owned by root:
 - `/usr/bin/riemann`
 - `/usr/{share,lib}/riemann`
 - `/etc/init.d/riemann`
 - `/etc/{default,sysconfig}/riemann`
