### PR TITLE
cache maven downloads between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
+sudo: false
 language: clojure
 lein: lein2
 jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
+
+cache:
+  directories:
+    - $HOME/.m2


### PR DESCRIPTION
this caches maven downloads between builds, which requires the use of
travis ci's new caching infrastructure. Should speed up builds quite a
bit