### PR TITLE
Removed daemonize

### DIFF
--- a/pkg/rpm/init.sh
+++ b/pkg/rpm/init.sh
@@ -32,8 +32,9 @@ DAEMON_OPTS="${RIEMANN_OPTS} ${RIEMANN_CONFIG}"
 start() {
     echo -n $"Starting ${NAME}: "
     ulimit -n $NFILES
-#    daemon --pidfile $PID_FILE --user $RIEMANN_USER $DAEMON $DAEMON_OPTS
-    daemonize -u $RIEMANN_USER -p $PID_FILE -l $LOCK_FILE $DAEMON $DAEMON_OPTS
+    if [ ! -f $LOCK_FILE ]; then
+      daemon --pidfile $PID_FILE --user $RIEMANN_USER $DAEMON $DAEMON_OPTS
+    fi
     RETVAL=$?
     [ $RETVAL -eq 0 ] && touch $LOCK_FILE
     [ $RETVAL -eq 0 ] && success || failure

--- a/tasks/leiningen/fatrpm.clj
+++ b/tasks/leiningen/fatrpm.clj
@@ -178,8 +178,7 @@
     (set-mojo! "preinstallScriptlet" (scriptlet
                                        (file (:root project)
                                              "pkg" "deb" "preinst.sh")))
-    (set-mojo! "requires" (create-dependency ["jre >= 1.6.0"
-                                              "daemonize >= 1.7.3"]))
+    (set-mojo! "requires" (create-dependency ["jre >= 1.6.0"]))
     (.execute)))
 
 (defn extract-rpm


### PR DESCRIPTION
The daemonize package hasn't been updated for recent EPEL releases,
specifically 7 onwards. That means this RPM won't install on RHEL or
CentOS 7 or later.

I've replaced daemonize with daemon to get around this.