### PR TITLE
Apply configuration during tests

### DIFF
--- a/src/riemann/bin.clj
+++ b/src/riemann/bin.clj
@@ -76,6 +76,7 @@
                 (reset! config-file config)
                 (riemann.config/include @config-file)
                 (binding [test/*streams* (:streams @config/next-core)]
+                  (riemann.config/apply!)
                   (let [results (clojure.test/run-all-tests #".*-test")]
                     (if (and (zero? (:error results))
                              (zero? (:fail results)))


### PR DESCRIPTION
I'm not sure if this is the right way to go about it but my use-case is that I want to be able to query the index during tests.

Perhaps we could use the same method which is used for `riemann.tests/*streams*`?