### PR TITLE
Enable native epoll on Linux/amd64 only

### DIFF
--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -76,7 +76,8 @@
   "Provide native implementation of Netty for improved performance on
   Linux only. Provide pure-Java implementation of Netty on all other
   platforms. See http://netty.io/wiki/native-transports.html"
-  (if (.contains (. System getProperty "os.name") "Linux")
+  (if (and (.contains (. System getProperty "os.name") "Linux")
+           (.contains (. System getProperty "os.arch") "amd64"))
     {:event-loop-group-fn #(EpollEventLoopGroup.)
      :channel EpollServerSocketChannel}
     {:event-loop-group-fn #(NioEventLoopGroup.)


### PR DESCRIPTION
netty includes a 64-bit shared library wrapping the native epoll()
on Linux. Linux systems running on other architectures (i386, ARM)
will fail when trying to set up a tcp server:

Caused by: java.lang.UnsatisfiedLinkError: /tmp/libnetty-transport-native-epoll1780114878375104085.so: /tmp/libnetty-transport-native-epoll1780114878375104085.so: wrong ELF class: ELFCLASS64 (Possible cause: architecture word width mismatch)

See: https://github.com/aphyr/riemann/issues/505

Use the pure Java netty implementation on non-AMD64 architectures.