### PR TITLE
An example of what I'd like to achieve with extra properties from katja

### DIFF
--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -8,10 +8,13 @@
   missing a metric or service."
   [event]
   (when (and (:metric event) (:service event))
-    {:name (:service event)
-     :host (or (:host event) "")
-     :state (:state event)
-     :value (:metric event)}))
+    (merge
+      {:name (:service event)
+       :host (or (:host event) "")
+       :state (:state event)
+       :value (:metric event)
+       }
+      (apply dissoc event [:service :host :state :metric :tags :time ]))))
 
 (defn events->points
   "Takes a series fn that finds the series for a given event, and a sequence of


### PR DESCRIPTION
Tis been a while since I looked at Clojure or Riemann or Katja or Influx or anything in our monitoring stack so perhaps there is another way.

From Erlang we're routing events from various containers/services that we're managing like so

````erlang
  katja:send_event([
                    { service, Type },
                    { metric, Metric },
                    { attributes, [
                                   { <<"node">>, NodeName },
                                   { <<"dockerimage">>,ImageName }
                                  ]}
                   ]).
````

Currently these extra "attributes" are lost by Riemann in the code where we convert Events into Influx points. Passing them through as extra columns would be ideal.

This means that I can't then do a "group by" on this info in Grafana or any front-end consuming Influx which is a bit of nuisance.

The code attached to this PR isn't ideal because I can't see an analogue in the other drivers and it's just going to explode when other structures are in place (but it does have the desired effect)

Is there another way to achieve this?