### PR TITLE
bad metrics submitted to graphite server  to be set to -1 instead of throwing a stack trace

### DIFF
--- a/src/riemann/graphite.clj
+++ b/src/riemann/graphite.clj
@@ -131,7 +131,8 @@
       (when (:metric event)
         (with-pool [client pool (:claim-timeout opts)]
                    (let [string (str (join " " [(path event)
-                                                ((fn [x] (try (float x) (catch Exception e (float -1)))) (:metric event))
+                                                ((fn [x] (try (float x) (catch Exception e (str "NaN")))) (:metric event))
                                                 (int (:time event))])
                                      "\n")]
-                     (send-line client string)))))))
+                     (if (nil? (re-find #"\sNaN\s" string)) (send-line client string))
+                     ))))))

--- a/src/riemann/graphite.clj
+++ b/src/riemann/graphite.clj
@@ -131,7 +131,7 @@
       (when (:metric event)
         (with-pool [client pool (:claim-timeout opts)]
                    (let [string (str (join " " [(path event)
-                                                (float (:metric event))
+                                                ((fn [x] (try (float x) (catch Exception e (float 0)))) (:metric event))
                                                 (int (:time event))])
                                      "\n")]
                      (send-line client string)))))))

--- a/src/riemann/graphite.clj
+++ b/src/riemann/graphite.clj
@@ -131,7 +131,7 @@
       (when (:metric event)
         (with-pool [client pool (:claim-timeout opts)]
                    (let [string (str (join " " [(path event)
-                                                ((fn [x] (try (float x) (catch Exception e (float 0)))) (:metric event))
+                                                ((fn [x] (try (float x) (catch Exception e (float -1)))) (:metric event))
                                                 (int (:time event))])
                                      "\n")]
                      (send-line client string)))))))

--- a/test/riemann/graphite_test.clj
+++ b/test/riemann/graphite_test.clj
@@ -29,7 +29,7 @@
      (try
        (sendout! {:service "service1" :metric 1.0 :time 0})
        (sendout! {:service "service2" :metric 2.0 :time 0})
-       ; the next service does not follow protocol and should be droppec by the graphite server
+       ; the next service does not follow protocol and should be dropped by the graphite server
        ; see https://answers.launchpad.net/graphite/+question/173242
        (sendout! {:service "service3" :metric "NaN" :time 0})
        (Thread/sleep 100)

--- a/test/riemann/graphite_test.clj
+++ b/test/riemann/graphite_test.clj
@@ -29,7 +29,7 @@
      (try
        (sendout! {:service "service1" :metric 1.0 :time 0})
        (sendout! {:service "service2" :metric 2.0 :time 0})
-       ; service3 does not follow protocol and should be droppec by the graphite server
+       ; the next service does not follow protocol and should be droppec by the graphite server
        ; see https://answers.launchpad.net/graphite/+question/173242
        (sendout! {:service "service3" :metric "NaN" :time 0})
        (Thread/sleep 100)

--- a/test/riemann/graphite_test.clj
+++ b/test/riemann/graphite_test.clj
@@ -34,7 +34,7 @@
          (is (and (#{"service1" "service2"} (:service r1))
                   (= 1.0 (:metric r1))))
          (is (and (#{"service1" "service2"} (:service r2))
-                  (= 0.0 (:metric r2)))))
+                  (= -1.0 (:metric r2)))))
        (finally
          (client/close! client)
          (stop! core))))))

--- a/test/riemann/graphite_test.clj
+++ b/test/riemann/graphite_test.clj
@@ -28,13 +28,16 @@
          client   (client/tcp-client)]
      (try
        (sendout! {:service "service1" :metric 1.0 :time 0})
-       (sendout! {:service "service2" :metric "Nan" :time 0})
+       (sendout! {:service "service2" :metric 2.0 :time 0})
+       ; service3 does not follow protocol and should be droppec by the graphite server
+       ; see https://answers.launchpad.net/graphite/+question/173242
+       (sendout! {:service "service3" :metric "NaN" :time 0})
        (Thread/sleep 100)
        (let [[r1 r2] @(client/query client "true")]
          (is (and (#{"service1" "service2"} (:service r1))
                   (= 1.0 (:metric r1))))
          (is (and (#{"service1" "service2"} (:service r2))
-                  (= -1.0 (:metric r2)))))
+                  (= 2.0 (:metric r2)))))
        (finally
          (client/close! client)
          (stop! core))))))

--- a/test/riemann/graphite_test.clj
+++ b/test/riemann/graphite_test.clj
@@ -28,13 +28,13 @@
          client   (client/tcp-client)]
      (try
        (sendout! {:service "service1" :metric 1.0 :time 0})
-       (sendout! {:service "service2" :metric 1.0 :time 0})
+       (sendout! {:service "service2" :metric "Nan" :time 0})
        (Thread/sleep 100)
        (let [[r1 r2] @(client/query client "true")]
          (is (and (#{"service1" "service2"} (:service r1))
                   (= 1.0 (:metric r1))))
          (is (and (#{"service1" "service2"} (:service r2))
-                  (= 1.0 (:metric r2)))))
+                  (= 0.0 (:metric r2)))))
        (finally
          (client/close! client)
          (stop! core))))))


### PR DESCRIPTION
Often bad metrics are sent to riemann in graphite form

For example:
```
collectd.prod.role.hosta_example_com.statistc.foo-example nan 1423864504
```

Which causes a stack exception to be thrown, so instead set them to -1 with a test included

```
WARN [2015-02-13 13:55:04,742] defaultEventExecutorGroup-2-3 - riemann.transport.tcp - TCP handler caught
io.netty.handler.codec.DecoderException: java.lang.RuntimeException: Graphite server parse error (NaN metric): "collectd.prod.role.hosta_example_com.statistc.foo-example nan 1423864504 "
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:99)
        at riemann.transport.graphite.proxy$io.netty.handler.codec.MessageToMessageDecoder$ff19274a.channelRead(Unknown Source)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:333)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:319)
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:333)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:319)
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:161)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:333)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:319)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:787)
        at io.netty.channel.epoll.EpollSocketChannel$EpollSocketUnsafe.epollInReady(EpollSocketChannel.java:722)
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:326)
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:264)
        at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:116)
        at io.netty.util.concurrent.DefaultThreadFactory$DefaultRunnableDecorator.run(DefaultThreadFactory.java:137)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.RuntimeException: Graphite server parse error (NaN metric): "collectd.prod.role.hosta_example_com.statistc.foo-example nan 1423864504 "
        at riemann.transport.graphite$graphite_frame_decoder$fn__5167.invoke(graphite.clj:89)
        at riemann.transport.graphite.proxy$io.netty.handler.codec.MessageToMessageDecoder$ff19274a.decode(Unknown Source)
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:89)
        ... 16 more
```