### PR TITLE
Retain time specified in event

### DIFF
--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -12,6 +12,7 @@
       {:name (:service event)
        :host (or (:host event) "")
        :state (:state event)
+       :time (:time event)
        :value (:metric event)
        }
       (apply dissoc event [:service :host :state :metric :tags :time ]))))


### PR DESCRIPTION
The timestamp from the event should be retained in the influxdb point.