### PR TITLE
Specify seconds resolution in output to InfluxDB

### DIFF
--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -72,4 +72,4 @@
             points (events->points series events)]
         (when-not (empty? points)
           (doseq [[series points] points]
-            (influx/post-points client series points)))))))
+            (influx/post-points client series "s" points)))))))


### PR DESCRIPTION
The InfluxDB API defaults to millisecond resolution in timestamps while Riemann uses seconds internally. This specifies the seconds resolution in the write to InfluxDB