### PR TITLE
Put EXTRA_CLASSPATH after riemann.jar

### DIFF
--- a/pkg/deb/riemann
+++ b/pkg/deb/riemann
@@ -4,7 +4,7 @@ if [ -f /etc/default/riemann ]; then
     . /etc/default/riemann
 fi
 
-JAR="$EXTRA_CLASSPATH:/usr/share/riemann/riemann.jar"
+JAR="/usr/share/riemann/riemann.jar:$EXTRA_CLASSPATH"
 CONFIG="/etc/riemann/riemann.config"
 COMMAND="start"
 AGGRESSIVE_OPTS="-server -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSParallelRemarkEnabled -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -XX:+UseCompressedOops -XX:+CMSClassUnloadingEnabled"

--- a/pkg/rpm/riemann
+++ b/pkg/rpm/riemann
@@ -4,7 +4,7 @@ if [ -f /etc/sysconfig/riemann ]; then
     . /etc/sysconfig/riemann
 fi
 
-JAR="$EXTRA_CLASSPATH:/usr/lib/riemann/riemann.jar"
+JAR="/usr/lib/riemann/riemann.jar:$EXTRA_CLASSPATH"
 CONFIG="/etc/riemann/riemann.config"
 COMMAND="start"
 AGGRESSIVE_OPTS="-server -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSParallelRemarkEnabled -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -XX:+UseCompressedOops -XX:+CMSClassUnloadingEnabled"

--- a/pkg/tar/riemann
+++ b/pkg/tar/riemann
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 top="$(dirname "$0")/.."
 
-JAR="$top/lib/riemann.jar"
+JAR="$top/lib/riemann.jar:$EXTRA_CLASSPATH"
 CONFIG="$top/etc/riemann.config"
 COMMAND="start"
 AGGRESSIVE_OPTS="-server -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSParallelRemarkEnabled -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -XX:+UseCompressedOops -XX:+CMSClassUnloadingEnabled"
@@ -47,4 +47,4 @@ for arg in "$@"; do
   esac
 done
 
-exec java $OPTS -jar "$JAR" "$COMMAND" "$CONFIG"
+exec java $EXTRA_JAVA_OPTS $OPTS -cp "$JAR" riemann.bin "$COMMAND" "$CONFIG"


### PR DESCRIPTION
Ensures that Riemann's copy of it's classes and Clojure get loaded first.

This prevents the issue where an uberjar in `EXTRA_CLASSPATH` that includes an earlier version of Clojure can interfere with Riemann's classloading.