### PR TITLE
expire by branch if event is expired

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -1507,7 +1507,10 @@
              fork (if-let [fork (@table fork-name)]
                     fork
                     ((swap! table assoc fork-name (new-fork)) fork-name))]
-         (call-rescue event fork)))))
+         (do
+           (if (expired? event) (swap! table dissoc fork-name))
+           (call-rescue event fork))))))
+
 
 (defn changed
   "Passes on events only when (f event) differs from that of the previous


### PR DESCRIPTION
This commit removes by branch streams if an expired event flows through them. 
This allows using the by stream even if the resulting number of streams would be big - as long as an expire event is triggered to remove the old streams.