### PR TITLE
Include config files in alphabetic order

### DIFF
--- a/src/riemann/config.clj
+++ b/src/riemann/config.clj
@@ -398,7 +398,7 @@
     (binding [*config-file* path
               *ns* (find-ns 'riemann.config)]
       (if (.isDirectory file)
-        (doseq [f (file-seq file)]
+        (doseq [f (sort (file-seq file))]
           (when (config-file? f)
             (load-file (.toString f))))
         (load-file path)))))


### PR DESCRIPTION
By default `include` loads config files in no specific order, since `java.io.File.listFiles` (thus `file-seq`) does not guarantee the order of returned files. Sometimes we may want to guarantee it loads files in a specific order, e.g. putting common functions in a `00-core.clj` and name other files like `01-service-alerts.clj` etc so that `00-core.clj` is always loaded first to make the common functions available in other config files.

Since `java.io.File` implements `Comparable`, we can simply call `sort` after `file-seq`.