### PR TITLE
instrument the number of unique events in the index

### DIFF
--- a/src/riemann/core.clj
+++ b/src/riemann/core.clj
@@ -228,6 +228,10 @@
        (seq [this]
          (seq source))
 
+       Instrumented
+       (instrumentation/events [this]
+         (instrumentation/events source))
+
        ServiceEquiv
        (equiv? [this other]
          (and (satisfies? WrappedIndex other)

--- a/src/riemann/index.clj
+++ b/src/riemann/index.clj
@@ -98,7 +98,7 @@
       (events [this]
         (let [base {:state "ok" :time (unix-time)}]
           (map (partial merge base)
-               [{:service "riemann index event-count"
+               [{:service "riemann index size"
                  :metric (.size hm)}])))
 
       clojure.lang.Seqable

--- a/src/riemann/index.clj
+++ b/src/riemann/index.clj
@@ -10,7 +10,8 @@
   Index: indexing and querying events
   Seqable: returning a list of events
   Service: lifecycle management"
-  (:require [riemann.query :as query])
+  (:require [riemann.query :as query]
+            [riemann.instrumentation :refer [Instrumented]])
   (:use [riemann.time :only [unix-time]]
          riemann.service)
   (:import (org.cliffc.high_scale_lib NonBlockingHashMap)))
@@ -92,6 +93,13 @@
 
       (lookup [this host service]
         (.get hm [host service]))
+
+      Instrumented
+      (events [this]
+        (let [base {:state "ok" :time (unix-time)}]
+          (map (partial merge base)
+               [{:service "riemann index event-count"
+                 :metric (.size hm)}])))
 
       clojure.lang.Seqable
       (seq [this]

--- a/test/riemann/index_test.clj
+++ b/test/riemann/index_test.clj
@@ -2,6 +2,7 @@
   (:use riemann.index
         riemann.core
         riemann.query
+        [riemann.instrumentation :only [events]]
         [riemann.common :only [event]]
         [riemann.time :only [unix-time]]
         clojure.test)
@@ -71,6 +72,13 @@
            (is (= 5 (:metric (lookup i 1 1))))
            (is (= 7 (:metric (lookup i 1 2))))))
 
+(deftest nbhm-instrumentation
+  (let [i (wrap-index (index))]
+
+    (i {:host 1 :service 1 :metric 5 :time 0})
+    (i {:host 1 :service 2 :metric 7 :time 0})
+
+    (is (= 2 (:metric (first (filter #(= (:service %) "riemann index event-count") (events i))))))))
 
 (defn random-event
   [& {:as event}]

--- a/test/riemann/index_test.clj
+++ b/test/riemann/index_test.clj
@@ -78,7 +78,7 @@
     (i {:host 1 :service 1 :metric 5 :time 0})
     (i {:host 1 :service 2 :metric 7 :time 0})
 
-    (is (= 2 (:metric (first (filter #(= (:service %) "riemann index event-count") (events i))))))))
+    (is (= 2 (:metric (first (filter #(= (:service %) "riemann index size") (events i))))))))
 
 (defn random-event
   [& {:as event}]


### PR DESCRIPTION
implements `Instrumented` for the index, with just a single event for now - the number of unique service/host keyed events in there