### PR TITLE
check emails recipients are strings

### DIFF
--- a/src/riemann/email.clj
+++ b/src/riemann/email.clj
@@ -62,6 +62,10 @@
   ([smtp-opts msg-opts]
    (let [msg-opts (merge {:from "riemann"} msg-opts)]
      (fn make-stream [& recipients]
+       (assert (every? string? recipients)
+               (str "email was passed a recipient that wasn't a string: "
+                    (pr-str recipients)
+                    " if those are events, you'll wanna call (email \"someemail@example.com\")"))
        (fn stream [event]
          (let [msg-opts (if (empty? recipients)
                           msg-opts

--- a/test/riemann/email_test.clj
+++ b/test/riemann/email_test.clj
@@ -19,7 +19,19 @@
            (is (= @a [{} {:subject "subject foo"
                           :body    "body foo"}]))))
 
+(deftest email-test-erroring
+  (testing "sending an email integration test"
+    (let [email (mailer {:from "riemann-test"})]
+      (is (thrown? java.lang.AssertionError
+                   (email {:host "localhost"
+                           :service "email test"
+                           :state "ok"
+                           :description "all clear, uh, situation normal"
+                           :metric 3.14159
+                           :time (unix-time)}))))))
+
 (deftest ^:email ^:integration email-test
+  (testing "sending an email integration test"
          (let [email (mailer {:from "riemann-test"})
                stream (email "aphyr@aphyr.com")]
            (stream {:host "localhost"
@@ -27,4 +39,4 @@
                     :state "ok"
                     :description "all clear, uh, situation normal"
                     :metric 3.14159
-                    :time (unix-time)})))
+                    :time (unix-time)}))))


### PR DESCRIPTION
This helps with the case where you accidentally pass an event to the
result of `mailer`, in which there won't be any errors thrown (before
this commit).