### PR TITLE
Add -v option for riemann to display the version.

### DIFF
--- a/pkg/deb/riemann
+++ b/pkg/deb/riemann
@@ -19,12 +19,20 @@ Runs Riemann with the given configuration file.
 OPTIONS:
   -h    Show this message
   -a    Adds some default aggressive, nonportable JVM optimization flags.
+  -v    Output Riemann version and exit.
 
 COMMANDS:
   start    Start the Riemann server (this is the default)
   test     Run the configuration tests
 
   Any unrecognized options (e.g. -XX:+UseParNewGC) will be passed on to java.
+EOF
+}
+
+version()
+{
+  cat <<EOF
+_VERSION_
 EOF
 }
 
@@ -36,6 +44,10 @@ for arg in "$@"; do
       ;;
     "-h")
       usage
+      exit 0
+      ;;
+    "-v")
+      version
       exit 0
       ;;
     -*)

--- a/pkg/rpm/riemann
+++ b/pkg/rpm/riemann
@@ -19,12 +19,20 @@ Runs Riemann with the given configuration file.
 OPTIONS:
   -h    Show this message
   -a    Adds some default aggressive, nonportable JVM optimization flags.
+  -v    Output Riemann version and exit.
 
 COMMANDS:
   start    Start the Riemann server (this is the default)
   test     Run the configuration tests
 
   Any unrecognized options (e.g. -XX:+UseParNewGC) will be passed on to java.
+EOF
+}
+
+version()
+{
+  cat <<EOF
+_VERSION_
 EOF
 }
 
@@ -36,6 +44,10 @@ for arg in "$@"; do
       ;;
     "-h")
       usage
+      exit 0
+      ;;
+    "-v")
+      version
       exit 0
       ;;
     -*)

--- a/pkg/tar/riemann
+++ b/pkg/tar/riemann
@@ -16,12 +16,20 @@ Runs Riemann with the given configuration file.
 OPTIONS:
   -h    Show this message
   -a    Adds some default aggressive, nonportable JVM optimization flags.
+  -v    Output Riemann version and exit.
 
 COMMANDS:
   start    Start the Riemann server (this is the default)
   test     Run the configuration tests
 
   Any unrecognized options (e.g. -XX:+UseParNewGC) will be passed on to java.
+EOF
+}
+
+version()
+{
+  cat <<EOF
+_VERSION_
 EOF
 }
 
@@ -33,6 +41,10 @@ for arg in "$@"; do
       ;;
     "-h")
       usage
+      exit 0
+      ;;
+    "-v")
+      version
       exit 0
       ;;
     -*)

--- a/tasks/leiningen/fatdeb.clj
+++ b/tasks/leiningen/fatdeb.clj
@@ -104,8 +104,12 @@
 
     ; Binary
     (.mkdirs (file dir "usr" "bin"))
-    (copy (file (:root project) "pkg" "deb" "riemann")
-          (file dir "usr" "bin" "riemann"))
+    (spit
+     (file dir "usr" "bin" "riemann")
+     (clojure.string/replace
+      (slurp (file (:root project) "pkg" "deb" "riemann"))
+      "_VERSION_"
+      (:version project)))
     (.setExecutable (file dir "usr" "bin" "riemann") true false)
 
     ; Log dir

--- a/tasks/leiningen/tar.clj
+++ b/tasks/leiningen/tar.clj
@@ -40,14 +40,18 @@
 
     ; Jar
     (.mkdirs (file dir "lib"))
-    (copy (file (:root project) "target" 
+    (copy (file (:root project) "target"
                 (str "riemann-" (:version project) "-standalone.jar"))
           (file dir "lib" "riemann.jar"))
 
     ; Binary
     (.mkdirs (file dir "bin"))
-    (copy (file (:root project) "pkg" "tar" "riemann")
-          (file dir  "bin" "riemann"))
+    (spit
+     (file dir  "bin" "riemann")
+     (clojure.string/replace
+      (slurp (file (:root project) "pkg" "tar" "riemann"))
+      "_VERSION_"
+      (:version project)))
     (.setExecutable (file dir "bin" "riemann") true false)
 
     ; Config


### PR DESCRIPTION
A need this option for a check in my nose tests.

I didn't find a way to replace riemann file inside target/rpm workarea, so I created a temp file inside target, and deleted it once the rpm is build.

I tested the build for tar, rpm and deb, in all cases the packages contains a riemann that has -v option and that displays the correct version (0.2.10-SNAPSHOT)

