### PR TITLE
Add support for private servers; Migrate to v2 API

### DIFF
--- a/src/riemann/hipchat.clj
+++ b/src/riemann/hipchat.clj
@@ -2,7 +2,6 @@
       :author "Hubert Iwaniuk"}
   riemann.hipchat
   (:require [clj-http.client :as client]
-            [cheshire.core :as json]
             [clojure.string :refer [join]]))
 
 (defn- message-colour [ev]
@@ -15,8 +14,8 @@
          state
          "yellow")))
 
-(def ^:private chat-url
-  "https://api.hipchat.com/v1/rooms/message?format=json")
+(defn ^:private chat-url [server room]
+  (str "https://" server "/v2/room/" room "/notification"))
 
 (defn- format-message [ev]
   "Formats a message, accepts a single
@@ -31,7 +30,7 @@
               " \nMetric: " (:metric e)
               " \nDescription: " (:description e))) ev)))
 
-(defn- format-event [{:keys [room_id from notify message] :as conf} event]
+(defn- format-event [{:keys [message] :as conf} event]
   "Creates an event suitable for posting to hipchat."
   (merge {:color (message-colour event)}
          conf
@@ -40,8 +39,8 @@
 
 (defn- post
   "POST to the HipChat API."
-  [token {:keys [room_id from message notify] :as conf} event]
-  (client/post (str chat-url "&auth_token=" token)
+  [token {:keys [server room_id] :as conf} event]
+  (client/post (str (chat-url server room_id) "?auth_token=" token)
                {:form-params           (format-event (assoc conf :message_format "text") event)
                 :socket-timeout        5000
                 :conn-timeout          5000
@@ -49,17 +48,27 @@
                 :throw-entire-message? true}))
 
 (defn hipchat
-  "Creates a HipChat adapter. Takes your HipChat authentication token,
-   and returns a function which posts a message to a HipChat.
+  "Creates a HipChat adapter. Takes your HipChat v2 authentication token,
+  and returns a function which posts a message to a HipChat.
 
-  (let [hc (hipchat {:token \"...\"
+  You can any a personal or room-specific token, which can be obtained from
+  your profile page or a specific room.
+
+  More on api tokens at https://www.hipchat.com/docs/apiv2/auth
+
+  If you're using hosted HipChat, you can leave out :server (or set it to
+  'api.hipchat.com').
+
+  (let [hc (hipchat {:server \"...\"
+                     :token \"...\"
                      :room 12345
-                     :from \"Riemann reporting\"
                      :notify 0})]
     (changed-state hc))"
-  [{:keys [token room from notify]}]
+  [{:keys [server token room notify]}]
+  (if (not (= 40 (count token)))
+    (throw (IllegalArgumentException. "This adapter now requires a v2 API key")))
   (fn [e] (post token
-               {:room_id room
-                :from    from
-                :notify  notify}
+                {:server  (or server "api.hipchat.com")
+                 :room_id room
+                 :notify  notify}
                e)))

--- a/test/riemann/hipchat_test.clj
+++ b/test/riemann/hipchat_test.clj
@@ -3,9 +3,12 @@
         clojure.test)
   (:require [riemann.logging :as logging]))
 
+(def server (System/getenv "HIPCHAT_SERVER"))
 (def api-key (System/getenv "HIPCHAT_API_KEY"))
 (def room (System/getenv "HIPCHAT_ALERT_ROOM"))
-(def alert_user "Riemann_HC_Test")
+
+(when-not server
+  (println "export HIPCHAT_SERVER=\"...\" to run these tests."))
 
 (when-not api-key
   (println "export HIPCHAT_API_KEY=\"...\" to run these tests."))
@@ -16,7 +19,7 @@
 (logging/init)
 
 (deftest ^:hipchat ^:integration good_event
-  (let [hc (hipchat {:token api-key :room room :from alert_user :notify 0})]
+  (let [hc (hipchat {:server server :token api-key :room room :notify 0})]
     (hc {:host "localhost"
          :service "hipchat test good"
          :description "Testing a metric with ok state"
@@ -24,7 +27,7 @@
          :state "ok"})))
 
 (deftest ^:hipchat ^:integration error_event
-  (let [hc (hipchat {:token api-key :room room :from alert_user :notify 0})]
+  (let [hc (hipchat {:server server :token api-key :room room :notify 0})]
     (hc {:host "localhost"
          :service "hipchat test error"
          :description "Testing a metric with error state"
@@ -32,7 +35,7 @@
          :state "error"})))
 
 (deftest ^:hipchat ^:integration critical_event
-  (let [hc (hipchat {:token api-key :room room :from alert_user :notify 0})]
+  (let [hc (hipchat {:server server :token api-key :room room :notify 0})]
     (hc {:host "localhost"
          :service "hipchat test critical"
          :description "Testing a metric with critical state"
@@ -40,7 +43,7 @@
          :state "critical"})))
 
 (deftest ^:hipchat ^:integration yellow
-  (let [hc (hipchat {:token api-key :room room :from alert_user :notify 0})]
+  (let [hc (hipchat {:server server :token api-key :room room :notify 0})]
     (hc {:host "localhost"
          :service "hipchat test yellow"
          :description "Testing a metric with unknown state"
@@ -48,7 +51,7 @@
          :state "unknown"})))
 
 (deftest ^:hipchat ^:integration multiple_events
-  (let [hc (hipchat {:token api-key :room room :from alert_user :notify 0})]
+  (let [hc (hipchat {:server server :token api-key :room room :notify 0})]
     (hc [{:host "localhost"
           :service "hipchat multi 1"
           :description "Testing multiple metrics"


### PR DESCRIPTION
HipChat can now be installed on private servers. This adds support for this and also switches away from the deprecated v1 API.