### PR TITLE
email: allow sequentials as input

### DIFF
--- a/src/riemann/email.clj
+++ b/src/riemann/email.clj
@@ -61,13 +61,14 @@
           (mailer smtp-opts msg-opts)))
   ([smtp-opts msg-opts]
    (let [msg-opts (merge {:from "riemann"} msg-opts)]
-     (fn make-stream [& recipients]
-       (assert (every? string? recipients)
-               (str "email was passed a recipient that wasn't a string: "
-                    (pr-str recipients)
-                    " if those are events, you'll wanna call (email \"someemail@example.com\")"))
-       (fn stream [event]
-         (let [msg-opts (if (empty? recipients)
-                          msg-opts
-                          (merge msg-opts {:to recipients}))]
-           (email-event smtp-opts msg-opts event)))))))
+     (fn make-stream [& [head & tail :as args]]
+       (let [recipients (if (and (sequential? head) (empty? tail)) head args)]
+         (assert (every? string? recipients)
+                 (str "email was passed a recipient that wasn't a string: "
+                      (pr-str recipients)
+                      " if those are events, you'll wanna call (email \"someemail@example.com\")"))
+         (fn stream [event]
+           (let [msg-opts (if (empty? recipients)
+                            msg-opts
+                            (merge msg-opts {:to recipients}))]
+             (email-event smtp-opts msg-opts event))))))))

--- a/test/riemann/email_test.clj
+++ b/test/riemann/email_test.clj
@@ -23,12 +23,22 @@
   (testing "sending an email integration test"
     (let [email (mailer {:from "riemann-test"})]
       (is (thrown? java.lang.AssertionError
+                   (email [:a :b])))
+      (is (thrown? java.lang.AssertionError
                    (email {:host "localhost"
                            :service "email test"
                            :state "ok"
                            :description "all clear, uh, situation normal"
                            :metric 3.14159
                            :time (unix-time)}))))))
+
+(deftest email-test-list-input
+  (testing "sending an email to a list of recipients"
+    (let [p (promise)]
+      (with-redefs [riemann.email/email-event (fn [_ m _] (deliver p (:to m)))]
+        (let [email ((mailer) ["a@a.a" "b@b.b"])]
+          (email {:service "foo"}))
+        (is (= (deref  p 500 nil) ["a@a.a" "b@b.b"]))))))
 
 (deftest ^:email ^:integration email-test
   (testing "sending an email integration test"


### PR DESCRIPTION
This can be useful to avoid useless applies when recipient lists are fetched elsewhere than the raw config.