### PR TITLE
fixing problem with “name” change and rejected null values in influxdb rc31/rc32

### DIFF
--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -34,6 +34,7 @@
   (let [ignored-fields (set/union special-fields tag-fields)]
     (-> event
         (->> (remove (comp ignored-fields key))
+             (remove #(nil? (val %)))
              (map #(vector (name (key %)) (val %)))
              (into {}))
         (assoc "value" (:metric event)))))
@@ -112,7 +113,7 @@
   and metric."
   [tag-fields event]
   (when (and (:time event) (:service event) (:metric event))
-    {"name" (:service event)
+    {"measurement" (:service event)
      "time" (unix-to-iso8601 (:time event))
      "tags" (event-tags tag-fields event)
      "fields" (event-fields tag-fields event)}))

--- a/test/riemann/influxdb_test.clj
+++ b/test/riemann/influxdb_test.clj
@@ -58,7 +58,7 @@
 (deftest point-conversion
   (is (nil? (influxdb/event->point-9 #{} {:service "foo test", :time 1}))
       "Event with no metric is converted to nil")
-  (is (= {"name" "test service"
+  (is (= {"measurement" "test service"
           "time" "2015-04-07T00:32:45.000Z"
           "tags" {"host" "host-01"}
           "fields" {"value" 42.08}}
@@ -69,7 +69,7 @@
             :time 1428366765
             :metric 42.08}))
       "Minimal event is converted to point fields")
-  (is (= {"name" "service_api_req_latency"
+  (is (= {"measurement" "service_api_req_latency"
           "time" "2015-04-06T21:15:41.000Z"
           "tags" {"host" "www-dev-app-01.sfo1.example.com"
                   "sys" "www"


### PR DESCRIPTION
I noticed a problem with recent influxdb 0.9.0 rc31which rejects null values and rc32 where "name" in point structure has been renamed to "measurement". Just in case if find it useful I fixed these two issues.