### PR TITLE
Make Influx 0.9 work with latest

### DIFF
--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -35,6 +35,7 @@
     (-> event
         (->> (remove (comp ignored-fields key))
              (map #(vector (name (key %)) (val %)))
+             (filter (comp #(not (nil? %)) last))
              (into {}))
         (assoc "value" (:metric event)))))
 
@@ -112,7 +113,7 @@
   and metric."
   [tag-fields event]
   (when (and (:time event) (:service event) (:metric event))
-    {"name" (:service event)
+    {"measurement" (:service event)
      "time" (unix-to-iso8601 (:time event))
      "tags" (event-tags tag-fields event)
      "fields" (event-fields tag-fields event)}))


### PR DESCRIPTION
Influx 0.9 crashes when you send through null fields (No really, completely - it dies a horrible death complete with Go stack traces that put Clojure to shame), there are a ton of paths I can see that end up doing this, so it's easiest to just strip them out at this point in the code.

Also it's no longer "name" in Influx, it's "measurement" so I changed that too.

Same caveat as always, I don't Clojure any more so it's probably horrible.
