### PR TITLE
Update InfluxDB 0.9.0 writer

### DIFF
--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -192,14 +192,12 @@
         tag-fields (:tag-fields opts #{:host})]
     (fn stream
       [events]
-      (let [events (if (sequential? events) events (list events))
-            points (events->points-9 tag-fields events)]
-        (when-not (empty? points)
-          (->> points
-               (assoc payload-base "points")
-               (json/generate-string)
-               (assoc http-opts :body)
-               (http/post write-url)))))))
+      (when-let [points (events->points-9 tag-fields events)]
+        (->> points
+             (assoc payload-base "points")
+             (json/generate-string)
+             (assoc http-opts :body)
+             (http/post write-url))))))
 
 
 

--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -47,13 +47,14 @@
   (let [ignored-fields (set/union special-fields (marked-tags event))]
     (-> event
         (->> (remove (comp ignored-fields key))
+             (remove (comp nil? val))
              (map #(vector (name (key %)) (val %)))
              (into {}))
         (assoc "value" (:metric event)))))
 
 
 
-;; ## InfluxDB 0.8
+;; ## InfluxDB 0.8.x
 
 (defn event->point-8
   "Transform a Riemann event to an InfluxDB point, or nil if the event is
@@ -118,7 +119,7 @@
 
 
 
-;; ## InfluxDB 0.9
+;; ## InfluxDB 0.9.0
 
 (defn event->point-9
   "Converts a Riemann event into an InfluxDB point if it has a time, service,
@@ -126,7 +127,7 @@
   treated as a set of event attributes to use as InfluxDB series tags."
   [event]
   (when (and (:time event) (:service event) (:metric event))
-    {"name" (:service event)
+    {"measurement" (:service event)
      "time" (unix-to-iso8601 (:time event))
      "tags" (event-tags event)
      "fields" (event-fields event)}))

--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -43,7 +43,7 @@
   `metric` is converted to the `value` field, and any additional event fields
   which are not standard Riemann properties or marked as tags in the metadata
   will also be present."
-  [tag-fields event]
+  [event]
   (let [ignored-fields (set/union special-fields (marked-tags event))]
     (-> event
         (->> (remove (comp ignored-fields key))

--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -15,12 +15,25 @@
   #{:host :service :time :metric :tags :ttl})
 
 
+(defn mark-tags
+  "Marks an event with metadata that denotes a set of fields to use as
+  series tags in InfluxDB. Returns the updated event."
+  [fields event]
+  (vary-meta event update-in [::tags] set/union (set fields)))
+
+
+(defn marked-tags
+  "Returns a set of the fields marked as tags in InfluxDB."
+  [event]
+  (::tags (meta event)))
+
+
 (defn event-tags
   "Generates a map of InfluxDB tags from a Riemann event. Any fields in the
-  event which are named in `tag-fields` will be converted to a string key/value
-  entry in the tag map."
-  [tag-fields event]
-  (->> (select-keys event tag-fields)
+  event which are marked in the metadata will be converted to a string
+  key/value entry in the tag map."
+  [event]
+  (->> (select-keys event (marked-tags event))
        (map #(vector (name (key %)) (str (val %))))
        (into {})))
 
@@ -28,10 +41,10 @@
 (defn event-fields
   "Generates a map of InfluxDB fields from a Riemann event. The event's
   `metric` is converted to the `value` field, and any additional event fields
-  which are not standard Riemann properties or in `tag-fields` will also be
-  present."
+  which are not standard Riemann properties or marked as tags in the metadata
+  will also be present."
   [tag-fields event]
-  (let [ignored-fields (set/union special-fields tag-fields)]
+  (let [ignored-fields (set/union special-fields (marked-tags event))]
     (-> event
         (->> (remove (comp ignored-fields key))
              (map #(vector (name (key %)) (val %)))
@@ -109,20 +122,31 @@
 
 (defn event->point-9
   "Converts a Riemann event into an InfluxDB point if it has a time, service,
-  and metric."
-  [tag-fields event]
+  and metric. If the event's metadata contains a `::tags` key, it will be
+  treated as a set of event attributes to use as InfluxDB series tags."
+  [event]
   (when (and (:time event) (:service event) (:metric event))
     {"name" (:service event)
      "time" (unix-to-iso8601 (:time event))
-     "tags" (event-tags tag-fields event)
-     "fields" (event-fields tag-fields event)}))
+     "tags" (event-tags event)
+     "fields" (event-fields event)}))
 
 
 (defn events->points-9
-  "Converts a collection of Riemann events into InfluxDB points. Events which
-  map to nil are removed from the final collection."
+  "Converts one or more Riemann events into a seq of InfluxDB points. The given
+  set of tag fields will be applied to every event. Events which map to `nil`
+  are removed from the final collection."
   [tag-fields events]
-  (vec (remove nil? (map (partial event->point-9 tag-fields) events))))
+  (-> events
+      (cond->>
+        (not (sequential? events))
+          (list)
+        (seq tag-fields)
+          (map (partial mark-tags tag-fields)))
+      (->>
+        (map event->point-9)
+        (remove nil?)
+        (seq))))
 
 
 (defn influxdb-9

--- a/test/riemann/influxdb_test.clj
+++ b/test/riemann/influxdb_test.clj
@@ -56,20 +56,21 @@
 
 
 (deftest point-conversion
-  (is (nil? (influxdb/event->point-9 #{} {:service "foo test", :time 1}))
+  (is (nil? (influxdb/event->point-9 {:service "foo test", :time 1}))
       "Event with no metric is converted to nil")
-  (is (= {"name" "test service"
+  (is (= {"measurement" "test service"
           "time" "2015-04-07T00:32:45.000Z"
           "tags" {"host" "host-01"}
           "fields" {"value" 42.08}}
          (influxdb/event->point-9
-           #{:host}
-           {:host "host-01"
-            :service "test service"
-            :time 1428366765
-            :metric 42.08}))
+           (influxdb/mark-tags
+             #{:host}
+             {:host "host-01"
+              :service "test service"
+              :time 1428366765
+              :metric 42.08})))
       "Minimal event is converted to point fields")
-  (is (= {"name" "service_api_req_latency"
+  (is (= {"measurement" "service_api_req_latency"
           "time" "2015-04-06T21:15:41.000Z"
           "tags" {"host" "www-dev-app-01.sfo1.example.com"
                   "sys" "www"
@@ -81,20 +82,21 @@
                     "state" "ok"
                     "foo" "frobble"}}
          (influxdb/event->point-9
-           #{:host :sys :env :role :loc}
-           {:host "www-dev-app-01.sfo1.example.com"
-            :service "service_api_req_latency"
-            :time 1428354941
-            :metric 0.8025
-            :state "ok"
-            :description "A text description!"
-            :ttl 60
-            :tags ["one" "two" "red"]
-            :sys "www"
-            :env "dev"
-            :role "app"
-            :loc "sfo1"
-            :foo "frobble"}))
+           (influxdb/mark-tags
+             #{:host :sys :env :role :loc}
+             {:host "www-dev-app-01.sfo1.example.com"
+              :service "service_api_req_latency"
+              :time 1428354941
+              :metric 0.8025
+              :state "ok"
+              :description "A text description!"
+              :ttl 60
+              :tags ["one" "two" "red"]
+              :sys "www"
+              :env "dev"
+              :role "app"
+              :loc "sfo1"
+              :foo "frobble"})))
       "Full event is converted to point fields")
   (is (empty? (influxdb/events->points-9 #{} [{:service "foo test"}]))
       "Nil points are filtered from result"))


### PR DESCRIPTION
@aphyr fixes #574 

This PR contains two changes. The first is a minor fix for a breaking change introduced by the final 0.9.0 InfluxDB API. For... whatever reason, the `"name"` field changed to `"measurement"`, and `nil` field values are no longer permitted.

The second change is more architectural - rather than specifying a single set of fields to turn into InfluxDB tags, the information is carried in metadata on each event. This way, you can specify a _base set_ of tag fields, but individual events can opt their custom fields into tags. This way consumers can write streams to treat different metrics appropriately, for example declaring that `:response-code` and `:controller` on a website request event should be tags.