### PR TITLE
Do not escape slack markup formatting in custom formatter.

### DIFF
--- a/src/riemann/slack.clj
+++ b/src/riemann/slack.clj
@@ -112,5 +112,5 @@
                      {:payload (json/generate-string
                                  (merge
                                   {:channel channel, :username username, :icon_emoji icon}
-                                  (when text {:text (slack-escape text)})
+                                  (when text {:text text})
                                   (dissoc result :icon :text)))}})))))

--- a/test/riemann/slack_test.clj
+++ b/test/riemann/slack_test.clj
@@ -53,10 +53,11 @@
           (is (= (:body @post-request)
                  "{\"attachments\":[{\"fields\":[{\"title\":\"Riemann Event\",\"value\":\"Host:   localhost\\nService:   mailer\\nState:   error\\nDescription:   Mailer failed\\nMetric:   42\\nTag:   -\\n\",\"short\":true}]}],\"channel\":\"#test-channel\",\"username\":\"test-user\",\"icon_emoji\":\":warning:\"}"))))
 
-      (testing "escapes formatting characters in main message text"
-        (let [slacker (slack/slack any-account (with-formatter (fn [e] {:text (:host e)})))]
-          (slacker {:host "<>&"})
-          (is (seq (re-seq #"&lt;&gt;&amp;" (:body @post-request))))))
+      (testing "allows formatting characters in main message text with custom formatter"
+        (let [formatter (fn [e] {:text (str "<http://health.check.api/" (:service e) "|" (:service e) ">")})
+              slacker (slack/slack any-account (with-formatter formatter))]
+          (slacker {:service "my-service"})
+          (is (seq (re-seq #"<http://health\.check\.api/my-service\|my-service>" (:body @post-request))))))
 
       (testing "allows for empty message text"
         (let [slacker (slack/slack any-account (with-formatter (constantly {})))]


### PR DESCRIPTION
This allows custom formatters to make use of slack's markup formatting.
Without this change all text is escaped in custom formatters and the
caller cannot make use of markup formatting (hyperlinking, bold, etc.)