### PR TITLE
Allow graphite to take a function as host name

### DIFF
--- a/src/riemann/graphite.clj
+++ b/src/riemann/graphite.clj
@@ -10,7 +10,8 @@
   (:use [clojure.string :only [split join replace]]
         clojure.tools.logging
         riemann.pool
-        riemann.common))
+        riemann.common
+        [riemann.transport :only [resolve-host]]))
 
 (defprotocol GraphiteClient
   (open [client]
@@ -110,12 +111,12 @@
         pool (fixed-pool
                (fn []
                  (info "Connecting to " (select-keys opts [:host :port]))
-                 (let [host (:host opts)
+                 (let [host (resolve-host (:host opts))
                        port (:port opts)
                        client (open (condp = (:protocol opts)
                                       :tcp (GraphiteTCPClient. host port)
                                       :udp (GraphiteUDPClient. host port)))]
-                   (info "Connected")
+                   (info "Connected to" host)
                    client))
                (fn [client]
                  (info "Closing connection to "

--- a/src/riemann/transport.clj
+++ b/src/riemann/transport.clj
@@ -31,7 +31,9 @@
     (io.netty.util.concurrent Future
                               EventExecutorGroup
                               DefaultEventExecutorGroup
-                              ImmediateEventExecutor)))
+                              ImmediateEventExecutor)
+    (java.net InetAddress
+              UnknownHostException)))
 
 (defn ^DefaultChannelGroup channel-group
   "Make a channel group with a given name."
@@ -173,3 +175,11 @@
       {:ok false :error (str "parse error: " message)})
     (catch Exception ^Exception e
       {:ok false :error (.getMessage e)})))
+
+(defn resolve-host
+  "Resolves a hostname to a random IP"
+  [host]
+  (try
+    (.getHostAddress (rand-nth (InetAddress/getAllByName host)))
+    (catch UnknownHostException e
+      host)))


### PR DESCRIPTION
This allows you to dynamically change the host connected to by each connection in the pool.

For example, our graphite host has multiple IPs in its A record. A function such as this will allow us to spread the connections over several hosts:

```clojure
(defn resolve-host
  "Returns a function which resolves a hostname to one of the IP addresses the record
  returns.

  (resolve-host \"graphite.example.com\")"
  [host]
  (fn []
    (debug "Resolving" host)
    (try (let [env (doto (Properties.) (.put Context/INITIAL_CONTEXT_FACTORY "com.sun.jndi.dns.DnsContextFactory"))
               idc (InitialDirContext. env)
               attrs (.getAttributes idc host (into-array String ["A"]))
               attr (.get attrs "A")]
           (if (not (nil? attr))
             (let [realhost (.get attr (rand-int (.size attr)))]
               (info "Resolved" host "to" realhost)
               realhost)
             host))
         (catch Exception e (error "Exception:" (.getMessage e))))))

(def graph (graphite {:host (resolve-host "graphite.example.com")
                      :port 2003
                      :pool-size 8}))
```