### PR TITLE
JVM opt for disabling epoll

### DIFF
--- a/src/riemann/transport/tcp.clj
+++ b/src/riemann/transport/tcp.clj
@@ -77,7 +77,8 @@
   Linux only. Provide pure-Java implementation of Netty on all other
   platforms. See http://netty.io/wiki/native-transports.html"
   (if (and (.contains (. System getProperty "os.name") "Linux")
-           (.contains (. System getProperty "os.arch") "amd64"))
+           (.contains (. System getProperty "os.arch") "amd64")
+           (.equals (System/getProperty "netty.epoll.enabled" "true") "true"))
     {:event-loop-group-fn #(EpollEventLoopGroup.)
      :channel EpollServerSocketChannel}
     {:event-loop-group-fn #(NioEventLoopGroup.)


### PR DESCRIPTION
There are still cases where a Linux amd64 host can't use the netty epoll
driver - e.g. on CentOS 5, where the glibc version is too old to run it.

This change allows disabling the default and fallback to the pure-java
implementation by adding `-Dnetty.epoll.enabled=false` to JVM opts.