### PR TITLE
logging: fallback to "riemann" when an unknown layout is provided

### DIFF
--- a/src/riemann/logging.clj
+++ b/src/riemann/logging.clj
@@ -50,7 +50,10 @@
 (defn get-layout
   "Fetch a logging layout by name"
   [layout-name]
-  (get layouts (or layout-name :riemann)))
+  (let [layout (get layouts (or layout-name :riemann))]
+    (when (nil? layout)
+      (binding [*out* *err*] (println "invalid logging layout specified: " layout-name)))
+    (or layout (:riemann layouts))))
 
 (defn init
   "Initialize log4j. You will probably call this from the config file. You can


### PR DESCRIPTION
When providing an unknown layout, the user just doesn't get any log.

The usefulness of this PR is quite limited as it doesn't output an error message (too early). The user will be puzzled not getting the log in the expected layout while they were puzzled not getting the logs at all. Not sure what's the best.