### PR TITLE
Update Ganglia client wiki link

### DIFF
--- a/clients.html
+++ b/clients.html
@@ -196,7 +196,7 @@ title: Riemann - Clients
 
       <h2 id="ganglia">Ganglia</h2>
       <p>Ganglia can <a
-        href="http://sourceforge.net/apps/trac/ganglia/wiki/riemann_integration">forward
+        href="https://github.com/ganglia/monitor-core/wiki/Riemann-Integration">forward
         events to Riemann</a>.</p>
 
       <h2 id="graphite">Graphite</h2>


### PR DESCRIPTION
The Sourceforge wiki has gone away. Ganglia now uses the GitHub wiki.