### PR TITLE
Adds support for UnixNano timestamps in influxdb 0.9

### DIFF
--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -127,17 +127,17 @@
 
 
 ;; ## InfluxDB 0.9
-
 (defn event->point-9
   "Converts a Riemann event into an InfluxDB point if it has a time, service,
   and metric."
   [tag-fields event]
   (when (and (:time event) (:service event) (:metric event))
-    {"measurement" (:service event)
-     "time" (unix-to-iso8601 (:time event))
-     "tags" (event-tags tag-fields event)
-     "fields" (event-fields tag-fields event)}))
-
+    (let [base {"measurement" (:service event)
+                "tags" (event-tags tag-fields event)
+                "fields" (event-fields tag-fields event)}]
+      (try (assoc base "time" (unix-to-iso8601 (:time event)))
+           (catch Exception e (merge base {"precision" "n"
+                                           "time" (:time event)}))))))
 
 (defn events->points-9
   "Converts a collection of Riemann events into InfluxDB points. Events which

--- a/test/riemann/influxdb_test.clj
+++ b/test/riemann/influxdb_test.clj
@@ -69,6 +69,18 @@
             :time 1428366765
             :metric 42.08}))
       "Minimal event is converted to point fields")
+  (is (= {"measurement" "test service"
+          "time" 1441388186665842890
+          "precision" "n"
+          "tags" {"host" "host-01"}
+          "fields" {"value" 42.08}}
+         (influxdb/event->point-9
+           #{:host}
+           {:host "host-01"
+            :service "test service"
+            :time 1441388186665842890
+            :metric 42.08}))
+      "A UnixNano timestamp produces a precision tag")
   (is (= {"measurement" "service_api_req_latency"
           "time" "2015-04-06T21:15:41.000Z"
           "tags" {"host" "www-dev-app-01.sfo1.example.com"


### PR DESCRIPTION
If converting a timestamp from unix to is8601 causes an integer overflow, send the raw timestamp to influxdb. 

Fixes #600 
