### PR TITLE
Add -v and version command to display Lein or POM version

### DIFF
--- a/pkg/deb/riemann
+++ b/pkg/deb/riemann
@@ -19,6 +19,7 @@ Runs Riemann with the given configuration file.
 OPTIONS:
   -h    Show this message
   -a    Adds some default aggressive, nonportable JVM optimization flags.
+  -v    Show version and exit
 
 COMMANDS:
   start    Start the Riemann server (this is the default)
@@ -37,6 +38,10 @@ for arg in "$@"; do
     "-h")
       usage
       exit 0
+      ;;
+    "-v")
+      COMMAND="version"
+      CONFIG="show"
       ;;
     -*)
       OPTS="$OPTS $arg"

--- a/pkg/rpm/riemann
+++ b/pkg/rpm/riemann
@@ -19,6 +19,7 @@ Runs Riemann with the given configuration file.
 OPTIONS:
   -h    Show this message
   -a    Adds some default aggressive, nonportable JVM optimization flags.
+  -v    Show version and exit
 
 COMMANDS:
   start    Start the Riemann server (this is the default)
@@ -37,6 +38,10 @@ for arg in "$@"; do
     "-h")
       usage
       exit 0
+      ;;
+    "-v")
+      COMMAND="version"
+      CONFIG="show"
       ;;
     -*)
       OPTS="$OPTS $arg"

--- a/pkg/tar/riemann
+++ b/pkg/tar/riemann
@@ -16,6 +16,7 @@ Runs Riemann with the given configuration file.
 OPTIONS:
   -h    Show this message
   -a    Adds some default aggressive, nonportable JVM optimization flags.
+  -v    Show version and exit
 
 COMMANDS:
   start    Start the Riemann server (this is the default)
@@ -34,6 +35,10 @@ for arg in "$@"; do
     "-h")
       usage
       exit 0
+      ;;
+    "-v")
+      COMMAND="version"
+      CONFIG="show"
       ;;
     -*)
       OPTS="$OPTS $arg"


### PR DESCRIPTION
When the `riemann` script is run with `-v` or
`riemann.bin/-main` is called with "version show", print the
version to stdout and then exit.

Requiring a second argument after "version" is a hack to avoid
additional option handling changes to the three `riemann` scripts.