### PR TITLE
Xymon: ability to support more message types. Enable/Disable messages implementation

### DIFF
--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -6,7 +6,7 @@
             [clojure.math.numeric-tower :refer [ceil]])
   (:import java.net.Socket))
 
-(defn format-line
+(defn event->status
   "Formats an event as a Xymon status message:
 
   status[+LIFETIME][/group:GROUP] HOSTNAME.TESTNAME COLOR <additional text>
@@ -55,5 +55,5 @@
                      :port 1984} opts)]
     (fn [{:keys [state service] :as event}]
       (when (and state service)
-        (let [statusmessage (format-line event)]
+        (let [statusmessage (event->status event)]
           (send-line opts statusmessage))))))

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -64,7 +64,7 @@
   used as duration, same as LIFETIME in event->status.
   "
   [{:keys [host service ttl description]
-    :or {host "" service "*" ttl "" description ""}}]
+    :or {host "" service "*" description ""}}]
   (let [host (host->xymon host)
         service (service->xymon service)]
     (format "disable %s.%s %s %s"

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -65,8 +65,9 @@
    "
   [opts]
   (let [opts (merge {:host "127.0.0.1"
-                     :port 1984} opts)]
+                     :port 1984
+                     :formatter event->status} opts)]
     (fn [{:keys [state service] :as event}]
       (when (and state service)
-        (let [statusmessage (event->status event)]
+        (let [statusmessage ((:formatter opts) event)]
           (send-line opts statusmessage))))))

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -60,7 +60,8 @@
   Convert an event to a Xymon disable message:
   disable HOSTNAME.TESTNAME DURATION <additional text>
 
-  Fields mapping is the same as event-status'.
+  Fields mapping is the same as event->status'. Also, the event ttl is
+  used as duration, same as LIFETIME in event->status.
   "
   [{:keys [host service duration description]
     :or {host "" service "*" ttl "" description ""}}]

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -93,20 +93,6 @@
     (catch Exception e
       ((:error-handler opts) e))))
 
-(defn send-line-with-to
-  [opts line]
-  (try
-    (let [addr (InetSocketAddress. (:host opts) (:port opts))
-          sock (Socket.)]
-      (.connect sock addr (:timeout opts))
-      (.setSoTimeout sock (:timeout opts))
-      (with-open [writer (io/writer sock)]
-        (.write writer line)
-        (.flush writer))
-      (.close sock))
-    (catch Exception e
-      (error e "cannot not reach xymon host"))))
-
 (defn xymon
   "Returns a function which accepts an event and sends it to Xymon.
    Silently drops events when xymon is down. Attempts to reconnect

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -8,9 +8,14 @@
 
 
 (defn host->xymon
-  "Format an hostname for xymon. Basically, replace all dot chars by commas."
+  "Format an hostname for Xymon. Basically, replace all dot chars by commas."
   [host]
   (s/replace host "." ","))
+
+(defn service->xymon
+  "Format a service name to be understood by Xymon."
+  [service]
+  (s/replace service #"(\.| )" "_"))
 
 (defn event->status
   "Formats an event as a Xymon status message:
@@ -32,7 +37,7 @@
     :or {host "" service "" description "" state "unknown"}}]
   (let [ttl-prefix (if ttl (str "+" (int (ceil (/ ttl 60)))) "")
         host       (host->xymon host)
-        service    (s/replace service #"(\.| )" "_")]
+        service    (service->xymon service)]
     (format "status%s %s.%s %s %s\n"
             ttl-prefix host service state description)))
 
@@ -46,7 +51,7 @@
   [{:keys [host service]
     :or {host "" service ""}}]
   (let [host (host->xymon host)
-        service (s/replace service #"(\.| )" "_")]
+        service (service->xymon service)]
     (format "enable %s.%s" host service)))
 
 (defn send-line

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -63,7 +63,7 @@
   Fields mapping is the same as event->status'. Also, the event ttl is
   used as duration, same as LIFETIME in event->status.
   "
-  [{:keys [host service duration description]
+  [{:keys [host service ttl description]
     :or {host "" service "*" ttl "" description ""}}]
   (let [host (host->xymon host)
         service (service->xymon service)]

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -49,7 +49,7 @@
 
   "
   [{:keys [host service]
-    :or {host "" service ""}}]
+    :or {host "" service "*"}}]
   (let [host (host->xymon host)
         service (service->xymon service)]
     (format "enable %s.%s" host service)))

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -30,6 +30,19 @@
     (format "status%s %s.%s %s %s\n"
             ttl-prefix host service state description)))
 
+(defn event->enable
+  "
+  Convert an event to an Xymon enable message:
+
+  enable HOSTNAME.TESTNAME
+
+  "
+  [{:keys [host service]
+    :or {host "" service ""}}]
+  (let [host (s/replace host "." ",")
+        service (s/replace service #"(\.| )" "_")]
+    (format "enable %s.%s" host service)))
+
 (defn send-line
   "Connects to Xymon server, sends line, then closes the connection.
    This is a blocking operation and should happen on a separate thread."

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -47,12 +47,26 @@
 
   enable HOSTNAME.TESTNAME
 
+  if no service is provided, the complete host is enabled.
   "
   [{:keys [host service]
     :or {host "" service "*"}}]
   (let [host (host->xymon host)
         service (service->xymon service)]
     (format "enable %s.%s" host service)))
+
+(defn event->disable
+  "
+  Convert an event to a Xymon disable message:
+  disable HOSTNAME.TESTNAME DURATION <additional text>
+
+  Fields mapping is the same as event-status'.
+  "
+  [{:keys [host service duration description]
+    :or {host "" service "*" duration "" description ""}}]
+  (let [host (host->xymon host)
+        service (service->xymon service)]
+    (format "disable %s.%s %s %s" host service duration description)))
 
 (defn send-line
   "Connects to Xymon server, sends line, then closes the connection.

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -63,10 +63,11 @@
   Fields mapping is the same as event-status'.
   "
   [{:keys [host service duration description]
-    :or {host "" service "*" duration "" description ""}}]
+    :or {host "" service "*" ttl "" description ""}}]
   (let [host (host->xymon host)
         service (service->xymon service)]
-    (format "disable %s.%s %s %s" host service duration description)))
+    (format "disable %s.%s %s %s"
+            host service (int (ceil (/ ttl 60))) description)))
 
 (defn send-line
   "Connects to Xymon server, sends line, then closes the connection.

--- a/src/riemann/xymon.clj
+++ b/src/riemann/xymon.clj
@@ -6,6 +6,12 @@
             [clojure.math.numeric-tower :refer [ceil]])
   (:import java.net.Socket))
 
+
+(defn host->xymon
+  "Format an hostname for xymon. Basically, replace all dot chars by commas."
+  [host]
+  (s/replace host "." ","))
+
 (defn event->status
   "Formats an event as a Xymon status message:
 
@@ -25,7 +31,7 @@
   [{:keys [ttl host service state description]
     :or {host "" service "" description "" state "unknown"}}]
   (let [ttl-prefix (if ttl (str "+" (int (ceil (/ ttl 60)))) "")
-        host       (s/replace host "." ",")
+        host       (host->xymon host)
         service    (s/replace service #"(\.| )" "_")]
     (format "status%s %s.%s %s %s\n"
             ttl-prefix host service state description)))
@@ -39,7 +45,7 @@
   "
   [{:keys [host service]
     :or {host "" service ""}}]
-  (let [host (s/replace host "." ",")
+  (let [host (host->xymon host)
         service (s/replace service #"(\.| )" "_")]
     (format "enable %s.%s" host service)))
 

--- a/test/riemann/xymon_test.clj
+++ b/test/riemann/xymon_test.clj
@@ -59,6 +59,21 @@
     (doseq [[event line] pairs]
       (is (= line (event->enable event))))))
 
+(deftest ^:xymon-disable event->disable-test
+  (let [pairs [[{:ttl 123}
+                "disable .* 3 "]
+               [{:host "foo" :ttl 300}
+                "disable foo.* 5 "]
+               [{:host "foo" :service "bar" :ttl 1}
+                "disable foo.bar 1 "]
+               [{:host "foo" :service "bar" :description "desc" :ttl 61}
+                "disable foo.bar 2 desc"]
+               [{:host "foo.example.com" :service "bar service" :ttl 59
+                 :description "desc"}
+                "disable foo,example,com.bar_service 1 desc"]]]
+    (doseq [[event line] pairs]
+      (is (= line (event->disable event))))))
+
 (deftest ^:xymon ^:integration xymon-test
          (let [k (xymon nil)]
            (k {:host "riemann.local"

--- a/test/riemann/xymon_test.clj
+++ b/test/riemann/xymon_test.clj
@@ -30,6 +30,20 @@
     (doseq [[event line] pairs]
       (is (= line (event->status event))))))
 
+(deftest ^:xymon-enable event->enable-test
+  (let [pairs [[{}
+                "enable .*"]
+               [{:host "foo"}
+                "enable foo.*"]
+               [{:host "foo" :service "bar"}
+                "enable foo.bar"]
+               [{:host "foo.example.com" :service "bar"}
+                "enable foo,example,com.bar"]
+               [{:host "foo" :service "b  a.r"}
+                "enable foo.b__a_r"]]]
+    (doseq [[event line] pairs]
+      (is (= line (event->enable event))))))
+
 (deftest ^:xymon ^:integration xymon-test
          (let [k (xymon nil)]
            (k {:host "riemann.local"

--- a/test/riemann/xymon_test.clj
+++ b/test/riemann/xymon_test.clj
@@ -6,7 +6,7 @@
 
 (logging/init)
 
-(deftest ^:xymon-format format-line-test
+(deftest ^:xymon-format event->status-test
   (let [pairs [[{}
                 "status . unknown \n"]
                [{:host "foo" :service "bar"}
@@ -28,7 +28,7 @@
                [{:host "example.com" :service "some.metric rate" :state "ok"}
                 "status example,com.some_metric_rate ok \n"]]]
     (doseq [[event line] pairs]
-      (is (= line (format-line event))))))
+      (is (= line (event->status event))))))
 
 (deftest ^:xymon ^:integration xymon-test
          (let [k (xymon nil)]

--- a/test/riemann/xymon_test.clj
+++ b/test/riemann/xymon_test.clj
@@ -6,6 +6,13 @@
 
 (logging/init)
 
+(deftest ^:xymon-host-xymon host->xymon-test
+  (let [pairs [["foo" "foo"]
+               ["example.com" "example,com"]
+               ["foo.example.com" "foo,example,com"]]]
+    (doseq [[hostname xymon-hostname] pairs]
+      (is (= xymon-hostname (host->xymon hostname))))))
+
 (deftest ^:xymon-format event->status-test
   (let [pairs [[{}
                 "status . unknown \n"]

--- a/test/riemann/xymon_test.clj
+++ b/test/riemann/xymon_test.clj
@@ -13,6 +13,14 @@
     (doseq [[hostname xymon-hostname] pairs]
       (is (= xymon-hostname (host->xymon hostname))))))
 
+(deftest ^:xymon-service-xymon service->xymon-test
+  (let [pairs [["foo" "foo"]
+               ["service name" "service_name"]
+               ["service.name" "service_name"]
+               ["s   erv..ice" "s___erv__ice"]]]
+    (doseq [[service xymon-service] pairs]
+      (is (= xymon-service (service->xymon service))))))
+
 (deftest ^:xymon-format event->status-test
   (let [pairs [[{}
                 "status . unknown \n"]


### PR DESCRIPTION
Summary:
* the `format-line` function is renamed as `event->status`, since it converts an event to "status" type messages to Xymon.
* the `xymon` function can take a "`:formatter`" option to send different type of message, but remains compatible with previous implementation.
* the `xymon` and  `send-line` functions can also take a `:timeout` option to make the Xymon socket timeout on both connect and read operations.
* New `event->enable` and `event->disable` functions to create respectively enable and disable type Xymon messages, which allow us to enable and disable Xymon monitoring through Riemann streams.