### PR TITLE
add insecure flag for influxdb in case cert is self-signed for https

### DIFF
--- a/src/riemann/influxdb.clj
+++ b/src/riemann/influxdb.clj
@@ -181,7 +181,8 @@
         (cond->
           {:socket-timeout (:timeout opts 5000) ; ms
            :conn-timeout   (:timeout opts 5000) ; ms
-           :content-type   "text/plain"}
+           :content-type   "text/plain"
+	   :insecure? (:insecure opts false)}
           (:username opts)
             (assoc :basic-auth [(:username opts)
                                 (:password opts)]))
@@ -228,6 +229,8 @@
   `:username`       Database user to authenticate as. (optional)
 
   `:password`       Password to authenticate with. (optional)
+
+  `:insecure`       If scheme is https and certficate is self-signed. (optional)
 
   See `influxdb-8` and `influxdb-9` for version-specific options."
   [opts]


### PR DESCRIPTION
I am running influxdb in https and some of my certificate are self-signed so insecure is quite handy, probably quite helpfull for testing as well.

I also noticed by doing some testing that the function  replace-disallowed-9 seems to send some warning, I'll open a ticket if its' not the right place to report it.


WARN [2015-09-24 02:56:23,257] pool-2-thread-1 - riemann.streams - riemann.influxdb$influxdb_9$stream__10995@6a4d7764 threw
java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.CharSequence
	at clojure.string$escape.invoke(string.clj:307)
	at riemann.influxdb$replace_disallowed_9.invoke(influxdb.clj:19)
	at riemann.influxdb$kv_encode_9$fn__10954.invoke(influxdb.clj:23)
	at clojure.core$map$fn__4245.invoke(core.clj:2559)
	at clojure.lang.LazySeq.sval(LazySeq.java:40)
	at clojure.lang.LazySeq.seq(LazySeq.java:49)
	at clojure.lang.LazySeq.first(LazySeq.java:71)
	at clojure.lang.RT.first(RT.java:577)
	at clojure.core$first.invoke(core.clj:55)
	at clojure.string$join.invoke(string.clj:185)
	at riemann.influxdb$kv_encode_9.invoke(influxdb.clj:22)
	at riemann.influxdb$lineprotocol_encode_9.invoke(influxdb.clj:26)
	at clojure.core$map$fn__4245.invoke(core.clj:2557)
	at clojure.lang.LazySeq.sval(LazySeq.java:40)
	at clojure.lang.LazySeq.seq(LazySeq.java:49)
	at clojure.lang.RT.seq(RT.java:484)
	at clojure.core$seq.invoke(core.clj:133)
	at clojure.core$apply.invoke(core.clj:624)
	at clojure.string$join.invoke(string.clj:183)
	at riemann.influxdb$lineprotocol_encode_list_9.invoke(influxdb.clj:36)
	at riemann.influxdb$influxdb_9$stream__10995.invoke(influxdb.clj:196)
	at riemann.streams$execute_on$stream__3889$runner__3890$fn__3901.invoke(streams.clj:268)
	at riemann.streams$execute_on$stream__3889$runner__3890.invoke(streams.clj:268)
	at clojure.lang.AFn.applyToHelper(AFn.java:152)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at clojure.core$apply.invoke(core.clj:624)
	at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1862)
	at clojure.lang.RestFn.invoke(RestFn.java:425)
	at clojure.lang.AFn.applyToHelper(AFn.java:156)
	at clojure.lang.RestFn.applyTo(RestFn.java:132)
	at clojure.core$apply.invoke(core.clj:628)
	at clojure.core$bound_fn_STAR_$fn__4140.doInvoke(core.clj:1884)
	at clojure.lang.RestFn.invoke(RestFn.java:397)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
	at java.lang.Thread.run(Thread.java:745)


