### PR TITLE
Bump the nREPL dep to 0.2.11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
     [org.clojure/clojure "1.6.0"]
     [org.clojure/math.numeric-tower "0.0.4"]
     [org.clojure/tools.logging "0.3.1"]
-    [org.clojure/tools.nrepl "0.2.10"]
+    [org.clojure/tools.nrepl "0.2.11"]
     [org.clojure/core.cache "0.6.4"]
     [org.clojure/data.priority-map "0.0.7"]
     [org.clojure/java.classpath "0.2.2"]


### PR DESCRIPTION
Some tools (e.g. CIDER) rely on the source-tracking evaluation support introduced in it.