### PR TITLE
Allow overriding graphite metric conversion method

### DIFF
--- a/src/riemann/graphite.clj
+++ b/src/riemann/graphite.clj
@@ -79,7 +79,8 @@
 (defn graphite-metric
   "convert riemann metric value to graphite"
   [event]
-  (float (:metric event)))
+  (let [val (:metric event)]
+    (if (integer? val) val (double val))))
 
 (defn graphite
   "Returns a function which accepts an event and sends it to Graphite.

--- a/src/riemann/graphite.clj
+++ b/src/riemann/graphite.clj
@@ -76,6 +76,11 @@
                                                 frac))))
       event)))
 
+(defn graphite-metric
+  "convert riemann metric value to graphite"
+  [event]
+  (float (:metric event)))
+
 (defn graphite
   "Returns a function which accepts an event and sends it to Graphite.
   Silently drops events when graphite is down. Attempts to reconnect
@@ -107,7 +112,8 @@
                      :protocol :tcp
                      :claim-timeout 0.1
                      :pool-size 4
-                     :path graphite-path-percentiles} opts)
+                     :path graphite-path-percentiles
+                     :metric graphite-metric} opts)
         pool (fixed-pool
                (fn []
                  (info "Connecting to " (select-keys opts [:host :port]))
@@ -132,7 +138,7 @@
       (when (:metric event)
         (with-pool [client pool (:claim-timeout opts)]
                    (let [string (str (join " " [(path event)
-                                                (float (:metric event))
+                                                (graphite-metric event)
                                                 (int (:time event))])
                                      "\n")]
                      (send-line client string)))))))

--- a/test/riemann/graphite_test.clj
+++ b/test/riemann/graphite_test.clj
@@ -74,6 +74,20 @@
                   {:service "foo bar 0.999"})
                 "foo.bar.999")))
 
+(deftest graphite-metric-test
+  (is (= (graphite-metric
+           {:metric 1000})
+         1000.0))
+  (is (= (graphite-metric
+           {:metric -2})
+         -2.0))
+  (is (= (graphite-metric
+           {:metric 8500000001})
+         (float 8500000001)))
+  (is (= (graphite-metric
+           {:metric 3.14159})
+         (float 3.14159))))
+
 (deftest ^:graphite ^:integration graphite-test
          (let [g (graphite {:block-start true})]
            (g {:host "riemann.local"

--- a/test/riemann/graphite_test.clj
+++ b/test/riemann/graphite_test.clj
@@ -77,16 +77,19 @@
 (deftest graphite-metric-test
   (is (= (graphite-metric
            {:metric 1000})
-         1000.0))
+         1000))
   (is (= (graphite-metric
            {:metric -2})
-         -2.0))
+         -2))
   (is (= (graphite-metric
            {:metric 8500000001})
-         (float 8500000001)))
+         8500000001))
+  (is (= (graphite-metric
+           {:metric 2/3})
+         (double 2/3)))
   (is (= (graphite-metric
            {:metric 3.14159})
-         (float 3.14159))))
+         (double 3.14159))))
 
 (deftest ^:graphite ^:integration graphite-test
          (let [g (graphite {:block-start true})]


### PR DESCRIPTION
I noticed some external verifications of what riemann was sending to graphite were failing due to lost precision of some `long` metrics because they're being converted into floats. I'm not sure if there's a good reason to use float vs double so I thought to allow overriding the function used to do the conversion.
