### PR TITLE
Fix percentiles documentation for correct service name

### DIFF
--- a/src/riemann/streams.clj
+++ b/src/riemann/streams.clj
@@ -860,7 +860,7 @@
   event.  If point is 1, takes the highest metric event. 0.5 is the median
   event, and so forth. Forwards each of these events to children. The service
   name has the point appended to it; e.g. 'response time' becomes 'response
-  time .95'."
+  time 0.95'."
   [interval points & children]
   (part-time-fast interval
                 (fn setup [] (atom []))


### PR DESCRIPTION
The current percentiles documentation suggest that the service name is changed like so:

    resource name

becomes

    resource name .95

In reality it becomes:

    resource name 0.95

This change updates the docs to reflect reality.