### PR TITLE
Post to HipChat in JSON format, and ensure 'notify' field is a boolean.

### DIFF
--- a/src/riemann/hipchat.clj
+++ b/src/riemann/hipchat.clj
@@ -42,6 +42,7 @@
   [token {:keys [server room_id] :as conf} event]
   (client/post (str (chat-url server room_id) "?auth_token=" token)
                {:form-params           (format-event (assoc conf :message_format "text") event)
+                :content-type          :json
                 :socket-timeout        5000
                 :conn-timeout          5000
                 :accept                :json
@@ -70,5 +71,5 @@
   (fn [e] (post token
                 {:server  (or server "api.hipchat.com")
                  :room_id room
-                 :notify  notify}
+                 :notify  (boolean notify)}
                e)))


### PR DESCRIPTION
HipChat Server API may have changed to require explicit boolean; this was causing an API error and undelivered events. This changes the post to comply with the API specs, so everybody is happy. Tests pass on both hosted and server versions.