### PR TITLE
Added support for a PagerDuty formatter for events

### DIFF
--- a/src/riemann/pagerduty.clj
+++ b/src/riemann/pagerduty.clj
@@ -17,30 +17,44 @@
                 :accept :json
                 :throw-entire-message? true}))
 
-(defn- format-event
-  "Formats an event for PD. event-type is one of :trigger, :acknowledge,
-  :resolve"
-  [service-key event-type event]
-  {:service_key service-key
-   :event_type event-type
-   :incident_key (str (:host event) " " (:service event))
+(defn format-event
+  "Formats an event for PagerDuty"
+  [event]
+  {:incident_key (str (:host event) " " (:service event))
    :description (str (:host event) " "
                      (:service event) " is "
                      (:state event) " ("
                      (:metric event) ")")
    :details event})
 
-(defn pagerduty
-  "Creates a pagerduty adapter. Takes your PD service key, and returns a map of
-  functions which trigger, acknowledge, and resolve events. Event service will
-  be used as the incident key. The PD description will be the service, state,
-  and metric. The full event will be attached as the details.
+(defn send-event
+  "Sends an event to PD. event-type is one of :trigger, :acknowledge,
+  :resolve"
+  [service-key event-type formatter event]
+  (merge
+    {:service_key service-key, :event_type event-type} (formatter event)))
 
-  (let [pd (pagerduty \"my-service-key\")]
+(defn pagerduty
+  "Creates a PagerDuty adapter. Takes your PD service key, and returns a map of
+  functions which trigger, acknowledge, and resolve events. By default, event
+  service will be used as the incident key. The PD description will be the service,
+  state, and metric. The full event will be attached as the details.
+
+  You can override this by specifying a formatter. The formatter must be a function that
+  accepts an event and emits a hash.
+
+  (defn pd-format-event
+    [event]
+    {:incident_key 'Incident key', :description 'Incident Description',
+     :details 'Incident details'})
+
+  The :formatter is an optional argument.
+
+  (let [pd (pagerduty :service-key \"my-service-key\" :formatter pd-format-event )]
     (changed-state
       (where (state \"ok\") (:resolve pd))
       (where (state \"critical\") (:trigger pd))))"
-  [service-key]
-  {:trigger     (fn [e] (post (format-event service-key :trigger e)))
-   :acknowledge (fn [e] (post (format-event service-key :acknowledge e)))
-   :resolve     (fn [e] (post (format-event service-key :resolve e)))})
+  [{:keys [service-key formatter] :or {formatter format-event}}]
+  {:trigger     (fn [e] (post (send-event service-key :trigger formatter e)))
+   :acknowledge (fn [e] (post (send-event service-key :acknowledge formatter e)))
+   :resolve     (fn [e] (post (send-event service-key :resolve formatter e)))})


### PR DESCRIPTION
This adds support for passing in a function name for a formatter for PagerDuty events. I suspect there's almost certainly a better way of doing this. Happy to take input on a better implementation. This was cut quickly to provide me with a solution.